### PR TITLE
Add unit tests for EmploymentTypeContainsKeywordsPredicate

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -120,7 +120,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                 String arg = argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).get();
                 String trimmedArg = arg.trim();
                 if (!trimmedArg.isEmpty()) {
-                    predicateList.add(new EmploymentTypeContainsKeywordsPredicate(trimmedArg));
+                    String[] keywords = splitByWhiteSpace(trimmedArg);
+                    predicateList.add(new EmploymentTypeContainsKeywordsPredicate(Arrays.asList(keywords)));
                 }
             }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -120,8 +120,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 String arg = argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).get();
                 String trimmedArg = arg.trim();
                 if (!trimmedArg.isEmpty()) {
-                    String[] keywords = splitByWhiteSpace(trimmedArg);
-                    predicateList.add(new EmploymentTypeContainsKeywordsPredicate(Arrays.asList(keywords)));
+                    predicateList.add(new EmploymentTypeContainsKeywordsPredicate(trimmedArg));
                 }
             }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -14,12 +14,16 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.EmploymentType;
 import seedu.address.model.person.EmploymentTypeContainsKeywordsPredicate;
 import seedu.address.model.person.ExpectedSalaryWithinRangePredicate;
 import seedu.address.model.person.ExperienceContainsKeywordsPredicate;
@@ -120,8 +124,14 @@ public class FindCommandParser implements Parser<FindCommand> {
                 String arg = argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).get();
                 String trimmedArg = arg.trim();
                 if (!trimmedArg.isEmpty()) {
-                    String[] keywords = splitByWhiteSpace(trimmedArg);
-                    predicateList.add(new EmploymentTypeContainsKeywordsPredicate(Arrays.asList(keywords)));
+                    List<String> keywords = new ArrayList<>();
+                    Pattern r = Pattern.compile(EmploymentType.Type.getRegex());
+                    Matcher m = r.matcher(trimmedArg);
+                    while (m.find()) {
+                        keywords.add(m.group());
+                    }
+                    System.out.println(keywords);
+                    predicateList.add(new EmploymentTypeContainsKeywordsPredicate(keywords));
                 }
             }
 

--- a/src/main/java/seedu/address/model/person/EmploymentType.java
+++ b/src/main/java/seedu/address/model/person/EmploymentType.java
@@ -18,7 +18,7 @@ public class EmploymentType {
 
         public static String getRegex() {
             StringBuilder regex = new StringBuilder("(?i)\\b(?:");
-            for (Type type: Type.values()){
+            for (Type type: Type.values()) {
                 regex.append(type.term);
                 regex.append("|");
             }

--- a/src/main/java/seedu/address/model/person/EmploymentType.java
+++ b/src/main/java/seedu/address/model/person/EmploymentType.java
@@ -15,6 +15,16 @@ public class EmploymentType {
         Type(String term) {
             this.term = term;
         }
+
+        public static String getRegex() {
+            StringBuilder regex = new StringBuilder("(?i)\\b(?:");
+            for (Type type: Type.values()){
+                regex.append(type.term);
+                regex.append("|");
+            }
+            regex.append("\\w+)\\b");
+            return regex.toString();
+        }
     }
 
     public static final String MESSAGE_CONSTRAINTS = "Employment type can only be one of the following: "

--- a/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
@@ -16,9 +16,8 @@ public class EmploymentTypeContainsKeywordsPredicate implements Predicate<Person
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil
-                        .containsWordIgnoreCase(person.getEmploymentType().employmentType, keyword));
-
+                .anyMatch(keyword -> person.getEmploymentType().employmentType.toLowerCase()
+                        .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
@@ -7,24 +7,30 @@ import seedu.address.commons.util.StringUtil;
 
 public class EmploymentTypeContainsKeywordsPredicate implements Predicate<Person> {
 
-    private final List<String> keywords;
+    private final String keyword;
 
-    public EmploymentTypeContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public EmploymentTypeContainsKeywordsPredicate(String keyword) {
+        this.keyword = keyword;
     }
+
+//    @Override
+//    public boolean test(Person person) {
+//        System.out.println(person.getEmploymentType().employmentType);
+//        return keywords.stream()
+//                .anyMatch(keyword -> StringUtil
+//                        .containsWordIgnoreCase(person.getEmploymentType().employmentType, keyword));
+//
+//    }
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil
-                        .containsWordIgnoreCase(person.getEmploymentType().employmentType, keyword));
-
+        return keyword.equalsIgnoreCase(person.getEmploymentType().employmentType);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof EmploymentTypeContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((EmploymentTypeContainsKeywordsPredicate) other).keywords)); // state check
+                && keyword.equals(((EmploymentTypeContainsKeywordsPredicate) other).keyword)); // state check
     }
 }

--- a/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 public class EmploymentTypeContainsKeywordsPredicate implements Predicate<Person> {
 
     private final List<String> keywords;

--- a/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicate.java
@@ -7,30 +7,24 @@ import seedu.address.commons.util.StringUtil;
 
 public class EmploymentTypeContainsKeywordsPredicate implements Predicate<Person> {
 
-    private final String keyword;
+    private final List<String> keywords;
 
-    public EmploymentTypeContainsKeywordsPredicate(String keyword) {
-        this.keyword = keyword;
+    public EmploymentTypeContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
     }
-
-//    @Override
-//    public boolean test(Person person) {
-//        System.out.println(person.getEmploymentType().employmentType);
-//        return keywords.stream()
-//                .anyMatch(keyword -> StringUtil
-//                        .containsWordIgnoreCase(person.getEmploymentType().employmentType, keyword));
-//
-//    }
 
     @Override
     public boolean test(Person person) {
-        return keyword.equalsIgnoreCase(person.getEmploymentType().employmentType);
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil
+                        .containsWordIgnoreCase(person.getEmploymentType().employmentType, keyword));
+
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof EmploymentTypeContainsKeywordsPredicate // instanceof handles nulls
-                && keyword.equals(((EmploymentTypeContainsKeywordsPredicate) other).keyword)); // state check
+                && keywords.equals(((EmploymentTypeContainsKeywordsPredicate) other).keywords)); // state check
     }
 }

--- a/src/test/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicateTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.tag.TagContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 
 public class EmploymentTypeContainsKeywordsPredicateTest {

--- a/src/test/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmploymentTypeContainsKeywordsPredicateTest.java
@@ -1,0 +1,84 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
+import seedu.address.testutil.PersonBuilder;
+
+public class EmploymentTypeContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Full time");
+        List<String> secondPredicateKeywordList = Arrays.asList("Full time", "Part time");
+
+        EmploymentTypeContainsKeywordsPredicate firstPredicate =
+                new EmploymentTypeContainsKeywordsPredicate(firstPredicateKeywordList);
+        EmploymentTypeContainsKeywordsPredicate secondPredicate =
+                new EmploymentTypeContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmploymentTypeContainsKeywordsPredicate firstPredicateCopy =
+                new EmploymentTypeContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_employmentTypeContainsKeywords_returnsTrue() {
+        // One keyword
+        EmploymentTypeContainsKeywordsPredicate predicate =
+                new EmploymentTypeContainsKeywordsPredicate(Collections.singletonList("Full time"));
+        assertTrue(predicate.test(new PersonBuilder().withEmploymentType("Full time").build()));
+
+        // Multiple keywords with only one matching keyword
+        predicate = new EmploymentTypeContainsKeywordsPredicate(Arrays.asList("Full time", "Part time"));
+        assertTrue(predicate.test(new PersonBuilder().withEmploymentType("Full time").build()));
+
+        // Mixed-case keywords
+        predicate = new EmploymentTypeContainsKeywordsPredicate(Arrays.asList("fULL tImE", "iNtErNshiP"));
+        assertTrue(predicate.test(new PersonBuilder().withEmploymentType("Internship").build()));
+
+    }
+
+    @Test
+    public void test_employmentTypeDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        EmploymentTypeContainsKeywordsPredicate predicate =
+                new EmploymentTypeContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withEmploymentType("Full time").build()));
+
+        // Non-matching keyword
+        predicate = new EmploymentTypeContainsKeywordsPredicate(Arrays.asList("Part time"));
+        assertFalse(predicate.test(new PersonBuilder().withEmploymentType("Temporary").build()));
+
+        // Keywords match name, phone, email, address, applied role, employment type, expected salary,
+        // level of education, years of experience and tags, but does not match employment type
+        predicate = new EmploymentTypeContainsKeywordsPredicate(
+                Arrays.asList("Alice", "12345", "alice@email.com", "Main",
+                "Street", "Software", "Engineer", "Full time", "4000", "PhD", "5", "young"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withRole("Software Engineer")
+                .withEmploymentType("Part time").withExpectedSalary("4000").withLevelOfEducation("PhD")
+                .withExperience("5").withTags("young").build()));
+
+    }
+}


### PR DESCRIPTION
Fixes #82 

### Changes
1. Added unit tests for EmploymentTypeContainsKeywordsPredicate
2. Changed find command for employment type for both partial and exact matching and is case insensitive
    - ```find et/time``` returns all applicants with either Full time or Part time employment types
    - ```find et/Full time``` no longer returns applicants with roles matching 'Full' or 'time', now returns applicants with Full time as role
    - ```find et/Full time part``` returns applicants with Full time or Part time employment types
    - ```find et/full part``` returns applicants with Full time or Part time employment types
    - ```find et/temp``` returns applicants with Temporary employment types
    - ```find et/xyz``` returns no applicants