### PR TITLE
Modify find command for level of education and addition of test cases

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -26,6 +26,7 @@ import seedu.address.model.person.EmploymentTypeContainsKeywordsPredicate;
 import seedu.address.model.person.ExpectedSalary;
 import seedu.address.model.person.ExpectedSalaryWithinRangePredicate;
 import seedu.address.model.person.ExperienceContainsKeywordsPredicate;
+import seedu.address.model.person.LevelOfEducation;
 import seedu.address.model.person.LevelOfEducationContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -141,7 +142,33 @@ public class FindCommandParser implements Parser<FindCommand> {
                 String trimmedArg = arg.trim();
                 if (!trimmedArg.isEmpty()) {
                     String[] keywords = splitByWhiteSpace(trimmedArg);
-                    predicateList.add(new LevelOfEducationContainsKeywordsPredicate(Arrays.asList(keywords)));
+                    ArrayList<String> validInputs = new ArrayList<>();
+                    int i = 0;
+                    boolean isValidInput = false;
+                    while (i < keywords.length) {
+                        if (LevelOfEducation.Education.combined().toLowerCase().contains(keywords[i].toLowerCase())) {
+                            isValidInput = true;
+                            validInputs.add(keywords[i]);
+                            System.out.println(validInputs.get(validInputs.size()-1));
+                        }
+                        if (keywords[i].equalsIgnoreCase("School") && (validInputs.size()>1)) {
+                            if ((keywords[i-1].equalsIgnoreCase("Middle"))
+                                    || (keywords[i-1].equalsIgnoreCase("High"))) {
+                                int size = validInputs.size();
+                                validInputs.remove(size-1);
+                                String a = validInputs.get(size-2);
+                                String b = a + " School";
+                                validInputs.remove(size-2);
+                                validInputs.add(b);
+                                System.out.println(validInputs.get(size-2));
+                            }
+                        }
+                        i++;
+                    }
+                    if (!isValidInput) {
+                        throw new ParseException(LevelOfEducation.MESSAGE_CONSTRAINTS);
+                    }
+                    predicateList.add(new LevelOfEducationContainsKeywordsPredicate(validInputs));
                 }
             }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -185,34 +185,30 @@ public class FindCommandParser implements Parser<FindCommand> {
                 String arg = argMultimap.getValue(PREFIX_LEVEL_OF_EDUCATION).get();
                 String trimmedArg = arg.trim();
                 if (!trimmedArg.isEmpty()) {
-                    String[] keywords = splitByWhiteSpace(trimmedArg);
-                    ArrayList<String> validInputs = new ArrayList<>();
-                    int i = 0;
-                    boolean isValidInput = false;
-                    while (i < keywords.length) {
-                        if (LevelOfEducation.Education.combined().toLowerCase().contains(keywords[i].toLowerCase())) {
-                            isValidInput = true;
-                            validInputs.add(keywords[i]);
-                            System.out.println(validInputs.get(validInputs.size()-1));
-                        }
-                        if (keywords[i].equalsIgnoreCase("School") && (validInputs.size()>1)) {
-                            if ((keywords[i-1].equalsIgnoreCase("Middle"))
-                                    || (keywords[i-1].equalsIgnoreCase("High"))) {
-                                int size = validInputs.size();
-                                validInputs.remove(size-1);
-                                String a = validInputs.get(size-2);
-                                String b = a + " School";
-                                validInputs.remove(size-2);
-                                validInputs.add(b);
-                                System.out.println(validInputs.get(size-2));
+                    List<String> keywords = new ArrayList<>();
+                    Pattern r = Pattern.compile(LevelOfEducation.Education.getRegex());
+                    Matcher m = r.matcher(trimmedArg);
+
+                    ArrayList<String> terms = LevelOfEducation.Education.getEducationLevels();
+
+                    while (m.find()) {
+                        if (!m.group().isEmpty()) {
+                            boolean contains = false;
+                            for (String term: terms) {
+                                if (term.toLowerCase().startsWith(m.group().toLowerCase())) {
+                                    contains = true;
+                                    break;
+                                }
+                            }
+
+                            if (!contains) {
+                                throw new ParseException(LevelOfEducation.FIND_MESSAGE_CONSTRAINTS);
+                            } else {
+                                keywords.add(m.group());
                             }
                         }
-                        i++;
                     }
-                    if (!isValidInput) {
-                        throw new ParseException(LevelOfEducation.MESSAGE_CONSTRAINTS);
-                    }
-                    predicateList.add(new LevelOfEducationContainsKeywordsPredicate(validInputs));
+                    predicateList.add(new LevelOfEducationContainsKeywordsPredicate(keywords));
                 }
             }
 

--- a/src/main/java/seedu/address/model/person/EmploymentType.java
+++ b/src/main/java/seedu/address/model/person/EmploymentType.java
@@ -42,8 +42,8 @@ public class EmploymentType {
     public static final String MESSAGE_CONSTRAINTS = "Employment type can only be one of the following: "
             + "Full time, Part time, Temporary or Internship";
 
-    public static final String FIND_MESSAGE_CONSTRAINTS = "You can only search for keywords that one or more of the"
-            + " following employment types: Full time, Part time, Temporary or Internship start with";
+    public static final String FIND_MESSAGE_CONSTRAINTS = "You can only search for keywords that start with "
+            + "one or more of the following employment types: Full time, Part time, Temporary or Internship";
 
     public final String employmentType;
 

--- a/src/main/java/seedu/address/model/person/LevelOfEducation.java
+++ b/src/main/java/seedu/address/model/person/LevelOfEducation.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.ArrayList;
+
 /**
  * Represents an Applicant's level of education in RecruitIn.
  */
@@ -32,7 +34,17 @@ public class LevelOfEducation {
             this.educationLevel = educationLevel;
         }
 
-        public static String combined() {
+        public static ArrayList<String> getEducationLevels() {
+            ArrayList<String> educationLevels = new ArrayList<>();
+
+            for (Education education: Education.values()) {
+                educationLevels.add(education.educationLevel);
+            }
+
+            return educationLevels;
+        }
+
+        public static String getRegex() {
             StringBuilder regex = new StringBuilder("(?i)\\b(?:");
             for (Education education: Education.values()) {
                 regex.append(education.educationLevel);
@@ -44,8 +56,12 @@ public class LevelOfEducation {
     }
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Level of Education should be one or a portion of the following: Elementary, Middle School,"
+            "Level of Education should only be one of the following: Elementary, Middle School,"
                     + " High School, University, Bachelors, Masters or PhD";
+
+    public static final String FIND_MESSAGE_CONSTRAINTS = "You can only search for keywords that start with "
+            + "one or more of the following levels of education: Elementary, Middle School, High School, University,"
+            + " Bachelors, Masters or PhD";
 
     public final String levelOfEducation;
 

--- a/src/main/java/seedu/address/model/person/LevelOfEducation.java
+++ b/src/main/java/seedu/address/model/person/LevelOfEducation.java
@@ -44,7 +44,7 @@ public class LevelOfEducation {
     }
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Level of Education should only be one of the following: Elementary, Middle School,"
+            "Level of Education should be one or a portion of the following: Elementary, Middle School,"
                     + " High School, University, Bachelors, Masters or PhD";
 
     public final String levelOfEducation;

--- a/src/main/java/seedu/address/model/person/LevelOfEducation.java
+++ b/src/main/java/seedu/address/model/person/LevelOfEducation.java
@@ -31,6 +31,16 @@ public class LevelOfEducation {
         Education(String educationLevel) {
             this.educationLevel = educationLevel;
         }
+
+        public static String combined() {
+            StringBuilder regex = new StringBuilder("(?i)\\b(?:");
+            for (Education education: Education.values()) {
+                regex.append(education.educationLevel);
+                regex.append("|");
+            }
+            regex.append("\\w+)\\b");
+            return regex.toString();
+        }
     }
 
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicate.java
@@ -19,8 +19,8 @@ public class LevelOfEducationContainsKeywordsPredicate implements Predicate<Pers
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil
-                        .containsWordIgnoreCase(person.getLevelOfEducation().levelOfEducation, keyword));
+                .anyMatch(keyword -> person.getLevelOfEducation().levelOfEducation.toLowerCase()
+                        .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class LevelOfEducationContainsKeywordsPredicate implements Predicate<Pers
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword -> person.getLevelOfEducation().levelOfEducation.toLowerCase()
-                        .contains(keyword.toLowerCase()));
+                        .startsWith(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Level of Education} matches any of the keywords given.
  */

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -27,6 +27,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.LevelOfEducationContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
@@ -180,6 +181,30 @@ public class FindCommandTest {
         assertEquals(Arrays.asList(HOON, IDA), modelWithHoonIda.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_zeroLevelOfEducationKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        ArrayList<Predicate<Person>> predicates = new ArrayList<>();
+        LevelOfEducationContainsKeywordsPredicate predicate = prepareLevelOfEducationPredicate(" ");
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleLevelOfEducationKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        ArrayList<Predicate<Person>> predicates = new ArrayList<>();
+        LevelOfEducationContainsKeywordsPredicate predicate =
+                prepareLevelOfEducationPredicate("Masters University");
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, GEORGE), model.getFilteredPersonList());
+    }
 
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
@@ -207,5 +232,12 @@ public class FindCommandTest {
      */
     private RoleContainsKeywordsPredicate prepareRolePredicate(String userInput) {
         return new RoleContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code PhoneContainsKeywordsPredicate}.
+     */
+    private LevelOfEducationContainsKeywordsPredicate prepareLevelOfEducationPredicate(String userInput) {
+        return new LevelOfEducationContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -189,6 +189,12 @@ public class FindCommandParserTest {
                 new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidExpectedSalaryPrefixInput,
                         PREFIX_EXPECTED_SALARY)));
 
+        String invalidLevelOfEducationTypePrefixInput = " l/Kindergarten"; // none of the levels of education
+        // start with this keyword
+        assertThrows(ParseException.class, () ->
+                new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidLevelOfEducationTypePrefixInput,
+                        PREFIX_LEVEL_OF_EDUCATION)));
+
         String invalidTagPrefixInput = " t/old(70)"; // brackets
         assertThrows(ParseException.class, () ->
                 new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidTagPrefixInput, PREFIX_TAG)));

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL_OF_EDUCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
@@ -27,7 +28,8 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -73,9 +75,15 @@ public class FindCommandParserTest {
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
-        String multipleEmptyPrefixInput = " n/ e/ p/ r/";
+        String emptyLevelOfEducationPrefixInput = " l/";
+        argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(emptyLevelOfEducationPrefixInput,
+                PREFIX_LEVEL_OF_EDUCATION);
+        findDescriptor = new FindDescriptor(argMultimap);
+        assertTrue(findDescriptor.getPredicates().isEmpty());
+
+        String multipleEmptyPrefixInput = " n/ e/ p/ r/ l/";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleEmptyPrefixInput,
-                PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE);
+                PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_LEVEL_OF_EDUCATION);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }
@@ -102,9 +110,15 @@ public class FindCommandParserTest {
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
-        String multipleBlankPrefixInput = " n/   e/   p/   r/  ";
+        String blankLevelOfEducationPrefixInput = " l/  ";
+        argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(blankLevelOfEducationPrefixInput,
+                PREFIX_LEVEL_OF_EDUCATION);
+        findDescriptor = new FindDescriptor(argMultimap);
+        assertTrue(findDescriptor.getPredicates().isEmpty());
+
+        String multipleBlankPrefixInput = " n/   e/   p/   r/   l/   ";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleBlankPrefixInput,
-                PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE);
+                PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_LEVEL_OF_EDUCATION);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }

--- a/src/test/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicateTest.java
@@ -43,9 +43,25 @@ public class LevelOfEducationContainsKeywordsPredicateTest {
 
     @Test
     public void test_levelOfEducationContainsKeywords_returnsTrue() {
-        // One keyword
+        // One matching letter
         LevelOfEducationContainsKeywordsPredicate predicate =
-                new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("Masters"));
+                new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("M"));
+        assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("Masters").build()));
+
+        // One keyword
+        predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("Masters"));
+        assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("Masters").build()));
+
+        // One portion of a two word category
+        predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("School"));
+        assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("High School").build()));
+
+        // Both parts of a two word category
+        predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("High School"));
+        assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("High School").build()));
+
+        // Mixed-case keywords
+        predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("maSteRS"));
         assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("Masters").build()));
     }
 
@@ -62,8 +78,9 @@ public class LevelOfEducationContainsKeywordsPredicateTest {
 
         // Keywords match name, phone, and email, but does not match level of education
         predicate = new LevelOfEducationContainsKeywordsPredicate(Arrays
-                .asList("Alice", "12345", "alice@email.com", "Main", "Street"));
+                .asList("Alice", "12345", "alice@email.com", "Engineer", "Temporary", "4000", "5", "old"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
-                .withEmail("alice@email.com").withLevelOfEducation("PhD").build()));
+                .withEmail("alice@email.com").withRole("Engineer").withEmploymentType("Temporary")
+                .withExpectedSalary("4000").withLevelOfEducation("PhD").withExperience("5").build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/LevelOfEducationContainsKeywordsPredicateTest.java
@@ -43,7 +43,7 @@ public class LevelOfEducationContainsKeywordsPredicateTest {
 
     @Test
     public void test_levelOfEducationContainsKeywords_returnsTrue() {
-        // One matching letter
+        // One matching letter that starts with
         LevelOfEducationContainsKeywordsPredicate predicate =
                 new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("M"));
         assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("Masters").build()));
@@ -52,8 +52,8 @@ public class LevelOfEducationContainsKeywordsPredicateTest {
         predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("Masters"));
         assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("Masters").build()));
 
-        // One portion of a two word category
-        predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("School"));
+        // First word of a two word category
+        predicate = new LevelOfEducationContainsKeywordsPredicate(Collections.singletonList("High"));
         assertTrue(predicate.test(new PersonBuilder().withLevelOfEducation("High School").build()));
 
         // Both parts of a two word category
@@ -71,6 +71,10 @@ public class LevelOfEducationContainsKeywordsPredicateTest {
         LevelOfEducationContainsKeywordsPredicate predicate =
                 new LevelOfEducationContainsKeywordsPredicate(Collections.emptyList());
         assertFalse(predicate.test(new PersonBuilder().withLevelOfEducation("PhD").build()));
+
+        // Keyword that is part of a level of education but does not start with it
+        predicate = new LevelOfEducationContainsKeywordsPredicate(Arrays.asList("School"));
+        assertFalse(predicate.test(new PersonBuilder().withLevelOfEducation("High School").build()));
 
         // Non-matching keyword
         predicate = new LevelOfEducationContainsKeywordsPredicate(Arrays.asList("Masters"));


### PR DESCRIPTION
Fixes #105 
Modify Find command with respect to Level of Education, such that a valid find command input must start with one of the Levels of Educaton

Fixes #115 
Add test cases in LevelOfEducationContainsKeywordsPredicateTest

Fixes #116 
Add test cases in FindCommandParserTest for Level of Education

Fixes #117 
Add test cases in FindCommandTest for Level of Education