### PR TITLE
Modify experience class & find command for it, add test cases

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -120,7 +120,11 @@ public class StringUtil {
         }
     }
 
-    public static boolean isIntegerLargerThanValue(String s1, String s2) {
+    /**
+     * Returns true if the integer represented by {@code s1} is larger than or equals to that by {@code s2}.
+     * @throws NullPointerException if {@code s1} or {@code s2} are null.
+     */
+    public static boolean isIntegerLargerOrEqualToValue(String s1, String s2) {
         CollectionUtil.requireAllNonNull(s1, s2);
         try {
             int value1 = Integer.parseInt(s1);

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -119,4 +119,15 @@ public class StringUtil {
             return false;
         }
     }
+
+    public static boolean isIntegerLargerThanValue(String s1, String s2) {
+        CollectionUtil.requireAllNonNull(s1, s2);
+        try {
+            int value1 = Integer.parseInt(s1);
+            int value2 = Integer.parseInt(s2);
+            return (value1 >= value2);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -26,6 +26,7 @@ import seedu.address.model.person.EmploymentType;
 import seedu.address.model.person.EmploymentTypeContainsKeywordsPredicate;
 import seedu.address.model.person.ExpectedSalary;
 import seedu.address.model.person.ExpectedSalaryWithinRangePredicate;
+import seedu.address.model.person.Experience;
 import seedu.address.model.person.ExperienceContainsKeywordsPredicate;
 import seedu.address.model.person.LevelOfEducation;
 import seedu.address.model.person.LevelOfEducationContainsKeywordsPredicate;
@@ -217,6 +218,11 @@ public class FindCommandParser implements Parser<FindCommand> {
                 String trimmedArg = arg.trim();
                 if (!trimmedArg.isEmpty()) {
                     String[] keywords = splitByWhiteSpace(trimmedArg);
+                    for (String keyword : keywords) {
+                        if (!Experience.isValidExperience(keyword)) {
+                            throw new ParseException(Experience.MESSAGE_CONSTRAINTS);
+                        }
+                    }
                     predicateList.add(new ExperienceContainsKeywordsPredicate(Arrays.asList(keywords)));
                 }
             }

--- a/src/main/java/seedu/address/model/person/ExpectedSalary.java
+++ b/src/main/java/seedu/address/model/person/ExpectedSalary.java
@@ -14,7 +14,7 @@ public class ExpectedSalary {
     public static final String MESSAGE_CONSTRAINTS = "Expected salary should only be a non-negative integer "
             + "(ranges from 0 to 2^(31) - 1 inclusive), and it should not be blank";
 
-    /*
+    /**
      * The first character of the salary must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */

--- a/src/main/java/seedu/address/model/person/Experience.java
+++ b/src/main/java/seedu/address/model/person/Experience.java
@@ -12,15 +12,15 @@ import seedu.address.commons.util.StringUtil;
 public class Experience {
 
     public static final String MESSAGE_CONSTRAINTS = "Experience should only contain numbers (no decimals), "
-            + "should be non-negative, and it should not be blank";
+            + "should be non-negative, not larger than 67 (re-employment age in Singapore), and it should not be blank";
 
-    /*
+    /**
      * The first character of the experience must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "\\d+";
 
-
+    public static final int MAX_EXPERIENCE = 67;
     public final String value;
 
     /**
@@ -40,7 +40,11 @@ public class Experience {
      * Returns true if a given number matches validation.
      */
     public static boolean isValidExperience(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (test.matches(VALIDATION_REGEX)) {
+            int value = Integer.parseInt(test);
+            return (value <= MAX_EXPERIENCE);
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Experience.java
+++ b/src/main/java/seedu/address/model/person/Experience.java
@@ -40,11 +40,15 @@ public class Experience {
      * Returns true if a given number matches validation.
      */
     public static boolean isValidExperience(String test) {
-        if (test.matches(VALIDATION_REGEX)) {
-            int value = Integer.parseInt(test);
-            return (value <= MAX_EXPERIENCE);
+        try {
+            if (test.matches(VALIDATION_REGEX)) {
+                int value = Integer.parseInt(test);
+                return (value <= MAX_EXPERIENCE);
+            }
+            return false;
+        } catch (NumberFormatException e) {
+            return false;
         }
-        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ExperienceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ExperienceContainsKeywordsPredicate.java
@@ -17,7 +17,7 @@ public class ExperienceContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword ->
-                        StringUtil.isIntegerLargerOrEqualToValue(person.getExperience().value,keyword));
+                        StringUtil.isIntegerLargerOrEqualToValue(person.getExperience().value, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ExperienceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ExperienceContainsKeywordsPredicate.java
@@ -17,7 +17,7 @@ public class ExperienceContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword ->
-                        StringUtil.containsWordIgnoreCase(person.getExperience().value, keyword));
+                        StringUtil.isIntegerLargerThanValue(person.getExperience().value,keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/ExperienceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ExperienceContainsKeywordsPredicate.java
@@ -17,7 +17,7 @@ public class ExperienceContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword ->
-                        StringUtil.isIntegerLargerThanValue(person.getExperience().value,keyword));
+                        StringUtil.isIntegerLargerOrEqualToValue(person.getExperience().value,keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -242,7 +242,7 @@ public class StringUtilTest {
                 Integer.toString(i + range + 2), range));
     }
 
-    //---------------- Tests for areUnsignedIntegersWithinRange ---------------------------
+    //---------------- Tests for isIntegerLargerOrEqualToValue ---------------------------
 
     @Test
     public void isIntegerLargerOrEqualToValue() {

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -242,4 +242,40 @@ public class StringUtilTest {
                 Integer.toString(i + range + 2), range));
     }
 
+    //---------------- Tests for areUnsignedIntegersWithinRange ---------------------------
+
+    @Test
+    public void isIntegerLargerOrEqualToValue() {
+        // EP: empty strings
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue("", ""));
+
+        // EP: not a number
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue("a", "b"));
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue("aaa", "bbb"));
+
+        // EP: numbers with white space
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue(" 10 ", "    20    ")); // Leading/trailing spaces
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue("1 0", "2 0")); // Spaces in the middle
+
+        // EP: number larger than Integer.MAX_VALUE
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue(Long.toString(Integer.MAX_VALUE + 1),
+                Long.toString(Integer.MAX_VALUE + 2)));
+
+        // EP: s1 >= s2, should return true
+        int small = 1;
+        int large = 10;
+        assertTrue(StringUtil.isIntegerLargerOrEqualToValue(Integer.toString(large),
+                Integer.toString(small)));
+        assertTrue(StringUtil.isIntegerLargerOrEqualToValue(Integer.toString(large + 5),
+                Integer.toString(small + 5)));
+
+        // EP: s1 < s2, should return false
+        int i = 5;
+        int j = 20;
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue(Integer.toString(i),
+                Integer.toString(j))); // Boundary value
+        assertFalse(StringUtil.isIntegerLargerOrEqualToValue(Integer.toString(i - 5),
+                Integer.toString(j - 5)));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -26,7 +26,15 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.*;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.EmploymentTypeContainsKeywordsPredicate;
+import seedu.address.model.person.ExpectedSalaryWithinRangePredicate;
+import seedu.address.model.person.ExperienceContainsKeywordsPredicate;
+import seedu.address.model.person.LevelOfEducationContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.RoleContainsKeywordsPredicate;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -26,14 +26,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.EmailContainsKeywordsPredicate;
-import seedu.address.model.person.EmploymentTypeContainsKeywordsPredicate;
-import seedu.address.model.person.ExpectedSalaryWithinRangePredicate;
-import seedu.address.model.person.LevelOfEducationContainsKeywordsPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.PhoneContainsKeywordsPredicate;
-import seedu.address.model.person.RoleContainsKeywordsPredicate;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 /**
@@ -309,6 +302,66 @@ public class FindCommandTest {
         assertEquals(Arrays.asList(BENSON, GEORGE), model.getFilteredPersonList());
     }
 
+
+    @Test
+    public void execute_zeroExperience_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        ArrayList<Predicate<Person>> predicates = new ArrayList<>();
+        ExperienceContainsKeywordsPredicate predicate = prepareExperiencePredicate(" ");
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneExperience_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        // Model with Hoon and Ida manually added
+        Model modelWithHoonIda = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        modelWithHoonIda.addPerson(HOON);
+        modelWithHoonIda.addPerson(IDA);
+
+        // Expected Model with Hoon and Ida manually added
+        Model expectedModelWithHoonIda = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModelWithHoonIda.addPerson(HOON);
+        expectedModelWithHoonIda.addPerson(IDA);
+
+        ArrayList<Predicate<Person>> predicates = new ArrayList<>();
+        ExperienceContainsKeywordsPredicate predicate =
+                prepareExperiencePredicate("7");
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
+        expectedModelWithHoonIda.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, modelWithHoonIda, expectedMessage, expectedModelWithHoonIda);
+        assertEquals(Arrays.asList(HOON, IDA), modelWithHoonIda.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleExperience_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        // Model with Hoon and Ida
+        Model modelWithHoonIda = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        modelWithHoonIda.addPerson(HOON);
+        modelWithHoonIda.addPerson(IDA);
+
+        // Expected Model with Hoon and Ida manually added
+        Model expectedModelWithHoonIda = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModelWithHoonIda.addPerson(HOON);
+        expectedModelWithHoonIda.addPerson(IDA);
+
+        ArrayList<Predicate<Person>> predicates = new ArrayList<>();
+        ExperienceContainsKeywordsPredicate predicate =
+                prepareExperiencePredicate("7 6");
+        predicates.add(predicate);
+        FindCommand command = new FindCommand(predicates);
+        expectedModelWithHoonIda.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, modelWithHoonIda, expectedMessage, expectedModelWithHoonIda);
+        assertEquals(Arrays.asList(GEORGE, HOON, IDA), modelWithHoonIda.getFilteredPersonList());
+    }
+
+
     @Test
     public void execute_zeroTagKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
@@ -380,6 +433,13 @@ public class FindCommandTest {
      */
     private LevelOfEducationContainsKeywordsPredicate prepareLevelOfEducationPredicate(String userInput) {
         return new LevelOfEducationContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code ExperienceContainsKeywordPredicate}.
+     */
+    private ExperienceContainsKeywordsPredicate prepareExperiencePredicate(String userInput) {
+        return new ExperienceContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -224,11 +224,6 @@ public class FindCommandParserTest {
                 new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidExperiencePrefixInput1,
                         PREFIX_EXPERIENCE)));
 
-        String invalidExperiencePrefixInput2 = " y/-11"; // negative number
-        assertThrows(ParseException.class, () ->
-                new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidExperiencePrefixInput2,
-                        PREFIX_EXPERIENCE)));
-
         String invalidTagPrefixInput = " t/old(70)"; // brackets
         assertThrows(ParseException.class, () ->
                 new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidTagPrefixInput, PREFIX_TAG)));

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -61,10 +62,10 @@ public class FindCommandParserTest {
     @Test
     public void findDescriptor_validPrefixInput_addToPredicateList() throws ParseException {
         String validExperiencePrefixInput = " y/3";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(validExperiencePrefixInput,
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(validExperiencePrefixInput,
                 PREFIX_EXPERIENCE);
         FindDescriptor findDescriptor = new FindDescriptor(argMultimap);
-        assertTrue(!findDescriptor.getPredicates().isEmpty());
+        assertFalse(findDescriptor.getPredicates().isEmpty());
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -121,7 +121,7 @@ public class FindCommandParserTest {
         String multipleEmptyPrefixInput = " n/ e/ p/ r/ et/ s/ l/ y/ t/ ";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleEmptyPrefixInput,
                 PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_EMPLOYMENT_TYPE,
-                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION,PREFIX_EXPERIENCE, PREFIX_TAG);
+                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_EXPERIENCE, PREFIX_TAG);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -2,7 +2,15 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYMENT_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_SALARY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPERIENCE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL_OF_EDUCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.FindCommandParser.FindDescriptor;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -2,14 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYMENT_TYPE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_SALARY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL_OF_EDUCATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.FindCommandParser.FindDescriptor;
@@ -95,15 +88,21 @@ public class FindCommandParserTest {
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
+        String emptyExperiencePrefixInput = " y/";
+        argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(emptyExperiencePrefixInput,
+                PREFIX_EXPERIENCE);
+        findDescriptor = new FindDescriptor(argMultimap);
+        assertTrue(findDescriptor.getPredicates().isEmpty());
+
         String emptyTagPrefixInput = " t/";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(emptyTagPrefixInput, PREFIX_TAG);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
-        String multipleEmptyPrefixInput = " n/ e/ p/ r/ et/ s/ l/ t/";
+        String multipleEmptyPrefixInput = " n/ e/ p/ r/ et/ s/ l/ t/ y/";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleEmptyPrefixInput,
                 PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_EMPLOYMENT_TYPE,
-                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_TAG);
+                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_TAG, PREFIX_EXPERIENCE);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }
@@ -147,15 +146,21 @@ public class FindCommandParserTest {
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
+        String blankExperiencePrefixInput = " y/  ";
+        argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(blankExperiencePrefixInput,
+                PREFIX_EXPERIENCE);
+        findDescriptor = new FindDescriptor(argMultimap);
+        assertTrue(findDescriptor.getPredicates().isEmpty());
+
         String blankTagPrefixInput = " t/  ";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(blankTagPrefixInput, PREFIX_TAG);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
-        String multipleBlankPrefixInput = " n/   e/   p/   r/   et/   s/   t/  ";
+        String multipleBlankPrefixInput = " n/   e/   p/   r/   et/   s/   t/  y/  ";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleBlankPrefixInput,
                 PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_EMPLOYMENT_TYPE,
-                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_TAG);
+                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_TAG, PREFIX_EXPERIENCE);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }
@@ -194,6 +199,16 @@ public class FindCommandParserTest {
         assertThrows(ParseException.class, () ->
                 new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidLevelOfEducationTypePrefixInput,
                         PREFIX_LEVEL_OF_EDUCATION)));
+
+        String invalidExperiencePrefixInput1 = " y/800"; // large number
+        assertThrows(ParseException.class, () ->
+                new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidExperiencePrefixInput1,
+                        PREFIX_EXPERIENCE)));
+
+        String invalidExperiencePrefixInput2 = " y/-11"; // negative number
+        assertThrows(ParseException.class, () ->
+                new FindDescriptor(ArgumentTokenizer.tokenizeWithoutPreamble(invalidExperiencePrefixInput2,
+                        PREFIX_EXPERIENCE)));
 
         String invalidTagPrefixInput = " t/old(70)"; // brackets
         assertThrows(ParseException.class, () ->

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -118,10 +118,10 @@ public class FindCommandParserTest {
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
-        String multipleEmptyPrefixInput = " n/ e/ p/ r/ et/ s/ l/ t/ y/";
+        String multipleEmptyPrefixInput = " n/ e/ p/ r/ et/ s/ l/ y/ t/ ";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleEmptyPrefixInput,
                 PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_EMPLOYMENT_TYPE,
-                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_TAG, PREFIX_EXPERIENCE);
+                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION,PREFIX_EXPERIENCE, PREFIX_TAG);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }
@@ -176,10 +176,10 @@ public class FindCommandParserTest {
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
 
-        String multipleBlankPrefixInput = " n/   e/   p/   r/   et/   s/   t/  y/  ";
+        String multipleBlankPrefixInput = " n/   e/   p/   r/   et/   s/   y/   t/   ";
         argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(multipleBlankPrefixInput,
                 PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE, PREFIX_EMPLOYMENT_TYPE,
-                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_TAG, PREFIX_EXPERIENCE);
+                PREFIX_EXPECTED_SALARY, PREFIX_LEVEL_OF_EDUCATION, PREFIX_EXPERIENCE, PREFIX_TAG);
         findDescriptor = new FindDescriptor(argMultimap);
         assertTrue(findDescriptor.getPredicates().isEmpty());
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -59,6 +59,16 @@ public class FindCommandParserTest {
 
     // Find Descriptor tests
     @Test
+    public void findDescriptor_validPrefixInput_addToPredicateList() throws ParseException {
+        String validExperiencePrefixInput = " y/3";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(validExperiencePrefixInput,
+                PREFIX_EXPERIENCE);
+        FindDescriptor findDescriptor = new FindDescriptor(argMultimap);
+        assertTrue(!findDescriptor.getPredicates().isEmpty());
+    }
+
+
+    @Test
     public void findDescriptor_emptyPrefixInput_emptyPredicatesList() throws ParseException {
         String emptyNamePrefixInput = " n/";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenizeWithoutPreamble(emptyNamePrefixInput, PREFIX_NAME);

--- a/src/test/java/seedu/address/model/person/ExperienceContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/ExperienceContainsKeywordsPredicateTest.java
@@ -56,9 +56,10 @@ public class ExperienceContainsKeywordsPredicateTest {
                 new ExperienceContainsKeywordsPredicate(Collections.emptyList());
         assertFalse(predicate.test(new PersonBuilder().withExperience("10").build()));
 
-        // Non-matching keyword
+        // entry less than keyword
         predicate = new ExperienceContainsKeywordsPredicate(Arrays.asList("3"));
-        assertFalse(predicate.test(new PersonBuilder().withExperience("10").build()));
+        assertFalse(predicate.test(new PersonBuilder().withExperience("1").build()));
+
 
         // Keywords match every other category except experience
         predicate = new ExperienceContainsKeywordsPredicate(Arrays.asList("Alice", "12345", "alice@email.com",
@@ -66,7 +67,7 @@ public class ExperienceContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withRole("Cat Whisperer")
                 .withEmploymentType("Full time").withExpectedSalary("3000")
-                .withLevelOfEducation("High School").withExperience("10").withTags("friend")
+                .withLevelOfEducation("High School").withExperience("1").withTags("friend")
                 .build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/ExperienceTest.java
+++ b/src/test/java/seedu/address/model/person/ExperienceTest.java
@@ -32,6 +32,8 @@ public class ExperienceTest {
         assertFalse(Experience.isValidExperience("1.11")); // contains decimals
         assertFalse(Experience.isValidExperience("-11")); // contains negative number
         assertFalse(Experience.isValidExperience("12345")); // number is too large
+        assertFalse(Experience.isValidExperience("12345678909876")); // long number
+
 
         // valid experience
         assertTrue(Experience.isValidExperience("1")); // positive number

--- a/src/test/java/seedu/address/model/person/ExperienceTest.java
+++ b/src/test/java/seedu/address/model/person/ExperienceTest.java
@@ -31,11 +31,11 @@ public class ExperienceTest {
         assertFalse(Experience.isValidExperience("11*")); // contains non-alphanumeric characters
         assertFalse(Experience.isValidExperience("1.11")); // contains decimals
         assertFalse(Experience.isValidExperience("-11")); // contains negative number
+        assertFalse(Experience.isValidExperience("12345")); // number is too large
 
 
 
         // valid experience
         assertTrue(Experience.isValidExperience("1")); // positive number
-        assertTrue(Experience.isValidExperience("12345")); // numbers only
     }
 }

--- a/src/test/java/seedu/address/model/person/ExperienceTest.java
+++ b/src/test/java/seedu/address/model/person/ExperienceTest.java
@@ -37,7 +37,8 @@ public class ExperienceTest {
 
         // valid experience
         assertTrue(Experience.isValidExperience("1")); // positive number
-        assertTrue(Experience.isValidExperience("67")); // number not larger than 67
+        assertTrue(Experience.isValidExperience(
+                Integer.toString(Experience.MAX_EXPERIENCE))); // number not larger than maximum
 
     }
 }

--- a/src/test/java/seedu/address/model/person/ExperienceTest.java
+++ b/src/test/java/seedu/address/model/person/ExperienceTest.java
@@ -27,15 +27,15 @@ public class ExperienceTest {
         // invalid experience
         assertFalse(Experience.isValidExperience("")); // empty string
         assertFalse(Experience.isValidExperience(" ")); // spaces only
-        assertFalse(Experience.isValidExperience("^")); // only non-alphanumeric characters
+        assertFalse(Experience.isValidExperience("^!@#$%")); // only non-alphanumeric characters
         assertFalse(Experience.isValidExperience("11*")); // contains non-alphanumeric characters
         assertFalse(Experience.isValidExperience("1.11")); // contains decimals
         assertFalse(Experience.isValidExperience("-11")); // contains negative number
         assertFalse(Experience.isValidExperience("12345")); // number is too large
 
-
-
         // valid experience
         assertTrue(Experience.isValidExperience("1")); // positive number
+        assertTrue(Experience.isValidExperience("67")); // number not larger than 67
+
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -105,7 +105,7 @@ public class TypicalPersons {
             .withEmploymentType("Part time")
             .withExpectedSalary("3300")
             .withLevelOfEducation("PhD")
-            .withExperience("3").build();
+            .withExperience("7").build();
 
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller")
             .withPhone("8482131")
@@ -114,7 +114,7 @@ public class TypicalPersons {
             .withEmploymentType("Full time")
             .withExpectedSalary("7100")
             .withLevelOfEducation("Masters")
-            .withExperience("7").build();
+            .withExperience("8").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY)


### PR DESCRIPTION
Fixes #95 #96 #98 #99 

Changes: 
- Show error message for invalid find command for `Experience`
- Find condition for `Experience` is changed from == to >= (e.g. 'find y/2' returns all entries with experience >=2 ) 
- Invalidate for too large experience input (>67) 
- Add test cases for `Experience` in `FindCommandParserTest` and `FindCommandTest`