### PR TITLE
Reduce method length and add defensive code for `ShowCommand` and `ShowCommandParser` classes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -2,15 +2,15 @@ package seedu.address.logic.commands;
 
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYMENT_TYPE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPECTED_SALARY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPERIENCE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL_OF_EDUCATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EMAIL_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EMPLOYMENT_TYPE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EXPECTED_SALARY_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EXPERIENCE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_LEVEL_OF_EDUCATION_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_NAME_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_PHONE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_ROLE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_TAG_SYNTAX;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -39,7 +39,16 @@ public class ShowCommand extends Command {
 
     private final Prefix prefix;
 
+    /**
+     * Constructor for ShowCommand.
+     * Prefix object passed as parameter cannot be null.
+     *
+     * @param prefix Category to get unique terms from.
+     */
     public ShowCommand(Prefix prefix) {
+
+        requireNonNull(prefix);
+
         this.prefix = prefix;
     }
 
@@ -55,6 +64,8 @@ public class ShowCommand extends Command {
 
     private String getUniqueCategoryInputs(Model model) {
 
+        assert prefix != null : "Prefix should not be null";
+
         // obtains an unmodifiable list of all applicants
         ReadOnlyAddressBook addressBook = model.getAddressBook();
         ObservableList<Person> ol = addressBook.getPersonList();
@@ -65,49 +76,45 @@ public class ShowCommand extends Command {
         Set<String> uniqueInputs = new HashSet<>();
         String userText = "";
 
-        if (prefixString.equals(PREFIX_NAME.getPrefix())) {
+        switch (prefixString) {
+        case PREFIX_NAME_SYNTAX:
             userText = "names";
             uniqueInputs = getUniqueNameInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_PHONE.getPrefix())) {
+            break;
+        case PREFIX_PHONE_SYNTAX:
             userText = "contact numbers";
             uniqueInputs = getUniquePhoneInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_EMAIL.getPrefix())) {
+            break;
+        case PREFIX_EMAIL_SYNTAX:
             userText = "emails";
             uniqueInputs = getUniqueEmailInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_ROLE.getPrefix())) {
+            break;
+        case PREFIX_ROLE_SYNTAX:
             userText = "roles";
             uniqueInputs = getUniqueRoleInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_EMPLOYMENT_TYPE.getPrefix())) {
+            break;
+        case PREFIX_EMPLOYMENT_TYPE_SYNTAX:
             userText = "employment types";
             uniqueInputs = getUniqueEmploymentTypeInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_EXPECTED_SALARY.getPrefix())) {
+            break;
+        case PREFIX_EXPECTED_SALARY_SYNTAX:
             userText = "expected salaries";
             uniqueInputs = getUniqueExpectedSalaryInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_LEVEL_OF_EDUCATION.getPrefix())) {
+            break;
+        case PREFIX_LEVEL_OF_EDUCATION_SYNTAX:
             userText = "levels of education";
             uniqueInputs = getUniqueLevelOfEducationInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_EXPERIENCE.getPrefix())) {
+            break;
+        case PREFIX_EXPERIENCE_SYNTAX:
             userText = "years of experience";
             uniqueInputs = getUniqueExperienceInputs(ol);
-        }
-
-        if (prefixString.equals(PREFIX_TAG.getPrefix())) {
+            break;
+        case PREFIX_TAG_SYNTAX:
             userText = "tags";
             uniqueInputs = getUniqueTagInputs(ol);
+            break;
+        default:
+            return "No search terms exist for unknown prefix " + prefixString;
         }
 
         if (!uniqueInputs.isEmpty()) {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,18 +1,28 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EMAIL_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EMPLOYMENT_TYPE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EXPECTED_SALARY_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_EXPERIENCE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_LEVEL_OF_EDUCATION_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_NAME_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_PHONE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_ROLE_SYNTAX;
+import static seedu.address.logic.parser.PrefixSyntax.PREFIX_TAG_SYNTAX;
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_ROLE = new Prefix("r/");
-    public static final Prefix PREFIX_EMPLOYMENT_TYPE = new Prefix("et/");
-    public static final Prefix PREFIX_EXPECTED_SALARY = new Prefix("s/");
-    public static final Prefix PREFIX_LEVEL_OF_EDUCATION = new Prefix("l/");
-    public static final Prefix PREFIX_EXPERIENCE = new Prefix("y/");
+    public static final Prefix PREFIX_NAME = new Prefix(PREFIX_NAME_SYNTAX);
+    public static final Prefix PREFIX_PHONE = new Prefix(PREFIX_PHONE_SYNTAX);
+    public static final Prefix PREFIX_EMAIL = new Prefix(PREFIX_EMAIL_SYNTAX);
+    public static final Prefix PREFIX_TAG = new Prefix(PREFIX_TAG_SYNTAX);
+    public static final Prefix PREFIX_ROLE = new Prefix(PREFIX_ROLE_SYNTAX);
+    public static final Prefix PREFIX_EMPLOYMENT_TYPE = new Prefix(PREFIX_EMPLOYMENT_TYPE_SYNTAX);
+    public static final Prefix PREFIX_EXPECTED_SALARY = new Prefix(PREFIX_EXPECTED_SALARY_SYNTAX);
+    public static final Prefix PREFIX_LEVEL_OF_EDUCATION = new Prefix(PREFIX_LEVEL_OF_EDUCATION_SYNTAX);
+    public static final Prefix PREFIX_EXPERIENCE = new Prefix(PREFIX_EXPERIENCE_SYNTAX);
 }

--- a/src/main/java/seedu/address/logic/parser/PrefixSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/PrefixSyntax.java
@@ -1,0 +1,18 @@
+package seedu.address.logic.parser;
+
+/**
+ * Contains strings that indicate Prefix commands.
+ */
+public class PrefixSyntax {
+
+    /* Prefix syntax */
+    public static final String PREFIX_NAME_SYNTAX = "n/";
+    public static final String PREFIX_PHONE_SYNTAX = "p/";
+    public static final String PREFIX_EMAIL_SYNTAX = "e/";
+    public static final String PREFIX_TAG_SYNTAX = "t/";
+    public static final String PREFIX_ROLE_SYNTAX = "r/";
+    public static final String PREFIX_EMPLOYMENT_TYPE_SYNTAX = "et/";
+    public static final String PREFIX_EXPECTED_SALARY_SYNTAX = "s/";
+    public static final String PREFIX_LEVEL_OF_EDUCATION_SYNTAX = "l/";
+    public static final String PREFIX_EXPERIENCE_SYNTAX = "y/";
+}

--- a/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowCommandParser.java
@@ -28,7 +28,6 @@ public class ShowCommandParser implements Parser<ShowCommand> {
 
         // One whitespace required before first prefix.
         String trimmedArgs = " " + args;
-        System.out.println(trimmedArgs);
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenizeWithoutPreamble(trimmedArgs, PREFIX_NAME,
@@ -51,6 +50,8 @@ public class ShowCommandParser implements Parser<ShowCommand> {
         private Prefix prefix;
 
         ShowDescriptor(ArgumentMultimap argMultimap) {
+
+            assert !argMultimap.isEmpty() : "ShowDescriptor should not be created with empty ArgumentMultimap";
 
             if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
                 prefix = PREFIX_NAME;


### PR DESCRIPTION
Addresses #155 

This PR will also introduce a new `PrefixSyntax` class that provides syntax for prefixes as constants.

For instance, the syntax for name prefix would be "n/".