### PR TITLE
Add tests for ShowCommand and ShowCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowCommand.java
@@ -12,8 +12,9 @@ import static seedu.address.logic.parser.PrefixSyntax.PREFIX_PHONE_SYNTAX;
 import static seedu.address.logic.parser.PrefixSyntax.PREFIX_ROLE_SYNTAX;
 import static seedu.address.logic.parser.PrefixSyntax.PREFIX_TAG_SYNTAX;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
@@ -73,7 +74,7 @@ public class ShowCommand extends Command {
         String prefixString = prefix.getPrefix();
 
         // temporary variables to hold unique search terms and part of UI message to user
-        Set<String> uniqueInputs = new HashSet<>();
+        List<String> uniqueInputs = new ArrayList<>();
         String userText = "";
 
         switch (prefixString) {
@@ -129,49 +130,61 @@ public class ShowCommand extends Command {
         }
     }
 
-    private Set<String> getUniqueNameInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueNameInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getName().toString()).collect(Collectors.toSet());
+                .map(x -> x.getName().toString()).distinct().sorted().collect(Collectors.toList());
     }
 
-    private Set<String> getUniquePhoneInputs(ObservableList<Person> ol) {
+    private List<String> getUniquePhoneInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getPhone().toString()).collect(Collectors.toSet());
+                .map(x -> x.getPhone().toString()).distinct().sorted().collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueEmailInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueEmailInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getEmail().toString()).collect(Collectors.toSet());
+                .map(x -> x.getEmail().toString()).distinct().sorted().collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueRoleInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueRoleInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getRole().toString()).collect(Collectors.toSet());
+                .map(x -> x.getRole().toString()).distinct().sorted().sorted().collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueEmploymentTypeInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueEmploymentTypeInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getEmploymentType().toString()).collect(Collectors.toSet());
+                .map(x -> x.getEmploymentType().toString()).distinct().sorted().collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueExpectedSalaryInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueExpectedSalaryInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getExpectedSalary().toString()).collect(Collectors.toSet());
+                .map(x -> x.getExpectedSalary().toString()).distinct()
+                .sorted(Comparator.comparing(String::length).thenComparing(String::compareTo))
+                .collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueLevelOfEducationInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueLevelOfEducationInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getLevelOfEducation().toString()).collect(Collectors.toSet());
+                .map(x -> x.getLevelOfEducation().toString()).distinct().sorted().collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueExperienceInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueExperienceInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .map(x -> x.getExperience().toString()).collect(Collectors.toSet());
+                .map(x -> x.getExperience().toString()).distinct()
+                .sorted(Comparator.comparing(String::length).thenComparing(String::compareTo))
+                .collect(Collectors.toList());
     }
 
-    private Set<String> getUniqueTagInputs(ObservableList<Person> ol) {
+    private List<String> getUniqueTagInputs(ObservableList<Person> ol) {
         return ol.stream()
-                .flatMap(person -> person.getTags().stream().map(Tag::toString)).collect(Collectors.toSet());
+                .flatMap(person -> person.getTags().stream().map(Tag::toString))
+                .distinct().sorted().collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ShowCommand // instanceof handles nulls
+                && prefix.equals(((ShowCommand) other).prefix)); // state check
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -120,6 +120,7 @@ public class CommandTestUtil {
             Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
+            System.out.println(result.getFeedbackToUser());
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {

--- a/src/test/java/seedu/address/logic/commands/ShowCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowCommandTest.java
@@ -1,0 +1,182 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.CliSyntax;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.Tag;
+
+public class ShowCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_namePrefix_namesListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the names present:\n");
+        List<String> names = getTypicalPersons().stream().map(x -> x.getName().toString())
+                .distinct().sorted().collect(Collectors.toList());
+        for (String name: names) {
+            expectedMessageSB.append(name);
+            expectedMessageSB.append("\n");
+        }
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_NAME);
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_phonePrefix_phonesListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the contact numbers present:\n");
+        List<String> phones = getTypicalPersons().stream().map(x -> x.getPhone().toString())
+                .distinct().sorted().collect(Collectors.toList());
+        for (String name: phones) {
+            expectedMessageSB.append(name);
+            expectedMessageSB.append("\n");
+        }
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_PHONE);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+    @Test
+    public void execute_emailPrefix_emailsListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the emails present:\n");
+        List<String> emails = getTypicalPersons().stream().map(x -> x.getEmail().toString())
+                .distinct().sorted().collect(Collectors.toList());
+        for (String email: emails) {
+            expectedMessageSB.append(email);
+            expectedMessageSB.append("\n");
+        }
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_EMAIL);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+    @Test
+    public void execute_rolePrefix_rolesListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the roles present:\n");
+        List<String> roles = getTypicalPersons().stream().map(x -> x.getRole().toString())
+                .distinct().sorted().collect(Collectors.toList());
+        for (String role: roles) {
+            expectedMessageSB.append(role);
+            expectedMessageSB.append("\n");
+        }
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_ROLE);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+    @Test
+    public void execute_employmentTypePrefix_employmentTypesListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the employment types present:\n");
+        List<String> employmentTypes = getTypicalPersons().stream().map(x -> x.getEmploymentType().toString())
+                .distinct().sorted().collect(Collectors.toList());
+        for (String employmentType: employmentTypes) {
+            expectedMessageSB.append(employmentType);
+            expectedMessageSB.append("\n");
+        }
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_EMPLOYMENT_TYPE);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+    @Test
+    public void execute_expectedSalaryPrefix_expectedSalariesListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the expected salaries present:\n");
+        List<String> expectedSalaries = getTypicalPersons().stream().map(x -> x.getExpectedSalary().toString())
+                .distinct().sorted(Comparator.comparing(String::length).thenComparing(String::compareTo))
+                .collect(Collectors.toList());
+        for (String expectedSalary: expectedSalaries) {
+            expectedMessageSB.append(expectedSalary);
+            expectedMessageSB.append("\n");
+        }
+
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_EXPECTED_SALARY);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+    @Test
+    public void execute_levelOfEducationPrefix_levelsOfEducationListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the levels of education present:\n");
+        List<String> levelsOfEducation = getTypicalPersons().stream().map(x -> x.getLevelOfEducation().toString())
+                .distinct().sorted().collect(Collectors.toList());
+        for (String levelOfEducation: levelsOfEducation) {
+            expectedMessageSB.append(levelOfEducation);
+            expectedMessageSB.append("\n");
+        }
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_LEVEL_OF_EDUCATION);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+
+    }
+
+    @Test
+    public void execute_experiencePrefix_experiencesListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the years of experience present:\n");
+        List<String> experiences = getTypicalPersons().stream().map(x -> x.getExperience().toString())
+                .distinct().sorted(Comparator.comparing(String::length).thenComparing(String::compareTo))
+                .collect(Collectors.toList());
+        for (String experience: experiences) {
+            expectedMessageSB.append(experience);
+            expectedMessageSB.append("\n");
+        }
+
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_EXPERIENCE);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+    @Test
+    public void execute_tagPrefix_tagsListed() {
+
+        StringBuilder expectedMessageSB = new StringBuilder("Here are all the tags present:\n");
+        List<String> tags = getTypicalPersons().stream()
+                .flatMap(person -> person.getTags().stream().map(Tag::toString))
+                .distinct().sorted().collect(Collectors.toList());
+        for (String tag: tags) {
+            expectedMessageSB.append(tag);
+            expectedMessageSB.append("\n");
+        }
+
+
+        String expectedMessage = expectedMessageSB.toString();
+        ShowCommand command = new ShowCommand(CliSyntax.PREFIX_TAG);
+        assertCommandSuccess(command, model, expectedMessage, model);
+
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/ShowCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ShowCommand;
+
+public class ShowCommandParserTest {
+
+    private ShowCommandParser parser = new ShowCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ShowCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidPrefix_throwsParseException() {
+        assertParseFailure(parser, "x/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ShowCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleValidPrefixes_returnsShowCommandWithLastPrefix() {
+
+        ShowCommand expectedShowCommand = new ShowCommand(CliSyntax.PREFIX_EMPLOYMENT_TYPE);
+        assertParseSuccess(parser, "n/ r/ et/", expectedShowCommand);
+
+        // multiple whitespaces between prefixes
+        assertParseSuccess(parser, "n/   r/    et/", expectedShowCommand);
+
+    }
+}


### PR DESCRIPTION
## Changes 

Fixes # 158 
* Adds tests for show command with prefix of each category
* Changed show command to return inputs of each category in alphabetical and numerical order, depending on category
(e.g. expected salaries shown numerically in order, roles shown alphabetically in order to make it easier for user to locate certain inputs)
* Changed from Set to List to hold all category inputs to make it easier to sort them and compare with expected message


Fixes # 159
* Adds test for show command with no prefixes after it (empty args)
* Adds test for show command with invalid prefix
* Adds test for show command with multiple inputs and multiple inputs with  extra whitespaces 
* Adds equals() to ShowCommand to compare ShowCommands in ShowCommandParserTest