### PR TITLE
Fix inability to find optional interview and note at first open

### DIFF
--- a/src/main/java/seedu/address/model/interview/InterviewContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewContainsKeywordsPredicate.java
@@ -26,7 +26,7 @@ public class InterviewContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
-                        person.getInterview().get().displayTime(), keyword));
+                        person.getInterview().orElse(Interview.EMPTY_INTERVIEW).displayTime(), keyword));
     }
 
 

--- a/src/main/java/seedu/address/model/notes/NotesContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/notes/NotesContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class NotesContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.getNotes().get().toString().toLowerCase().contains(keyword.toLowerCase());
+        return person.getNotes().orElse(Notes.EMPTY_NOTES).toString().toLowerCase().contains(keyword.toLowerCase());
     }
 
 


### PR DESCRIPTION
by changing `get()` to `orElse(EMPTY)` in test method in `containsKeywordsPredicate`