### PR TITLE
Modify UG to fix documentation errors

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -115,8 +115,7 @@ Scroll down to the bottom and click on `recruitIn.jar`.
 
 **:information_source: Notes about the applicants:**<br>
 
-* Duplicate applicants are not allowed. <br>
-  For two applicants to be duplicate, they must have either the same ***Phone Number*** or ***Email*** or both. 
+* Duplicate applicants are not allowed. For two applicants to be duplicate, they must have either the same ***Phone Number*** or ***Email*** or both. <br>
   An error message will show if you attempt to `add` or `edit` applicants in a manner that will lead to duplicate stored applicants.
 
 </div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -228,7 +228,18 @@ Format: `find [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMPLOYMEN
 * Find command must take **at least 1** prefix input.
 * If you input multiple of the same prefix, **only the last** prefix will be used for the search of that category.
 * Input for each prefix can contain multiple **keywords** separated by whitespace, e.g. `n/John Mary`, `t/friend colleague`
+
+<div markdown="span" class="alert alert-warning">
+* You can search for tags using multiple keywords by providing your keywords separated by whitespace in a `t/` prefix. (i.e. `find t/smart kind`)
+    * This is different from `add` and `edit` commands which require tag inputs to be provided separately. (i.e. `edit 1 t/smart t/kind`)
+</div>
+
 * Inputs for all prefixes are **case-insensitive**.
+
+<div markdown="span" class="alert alert-warning">
+* Applicants will not be filtered by prefixes that are not provided.
+* Applicants will also not be filtered by prefixes that are provided, yet have empty inputs. (i.e. `find d/` will return all applicants unfiltered by their ***done*** status)
+</div>
 
 Examples:
 * `find n/John Mary` finds all applicants with either `John` or `Mary` as values for name prefix.
@@ -257,6 +268,7 @@ Examples:
 | TAG | `t/` | [**tag**](#tag-t-1) |
 | INTERVIEW | `i/` | [**interview**](#interview-i-1) |
 | NOTES | `nt/` | [**notes**](#notes-nt-1) |
+| DONE | `d/` | [**done**](#done-d) |
 
 </div>
         

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,7 +147,7 @@ Examples:
 * `add n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 i/2021-10-21, 20:00 nt/This applicant has the credentials needed for this job.`
 * `add n/John p/90909090 e/john@gmail.com r/Software Tester et/Full time s/4500 l/High School y/3 t/smart t/helpful` to add a person named `John` with two tags `smart` and `helpful`
 
-<div markdown="block" class="alert alert-success">
+<div markdown="block" class="alert alert-secondary">
 **:information_source: Prefix inputs for `add` command must follow the following input specifications:**<br>
 
 * You may
@@ -156,17 +156,17 @@ Examples:
 
 | Input | Prefix | Specifications |
 | :---: | :---: | :---: |
-| NAME | `n/` | [name](#name-n) |
-| PHONE_NUMBER | `p/` | [phone_number](#phone_number-p) |
-| EMAIL_ADDRESS | `e/` | [email_address](#email_address-e) |
-| ROLE | `r/` | [role](#role-r) |
-| EMPLOYMENT_TYPE | `et/` | [employment_type](#employment_type-et) |
-| EXPECTED_SALARY | `s/` | [expected_salary](#expected_salary-s) |
-| LEVEL_OF_EDUCATION | `l/` | [level_of_education](#level_of_education-l) |
-| YEARS_OF_EXPERIENCE | `y/` | [years_of_experience](#years_of_experience-y) |
-| TAG | `t/` | [tag](#tag-t) |
-| INTERVIEW | `i/` | [interview](#interview-i) |
-| NOTES | `nt/` | [notes](#notes-nt) |
+| NAME | `n/` | [**name**](#name-n) |
+| PHONE_NUMBER | `p/` | [**phone_number**](#phone_number-p) |
+| EMAIL_ADDRESS | `e/` | [**email_address**](#email_address-e) |
+| ROLE | `r/` | [**role**](#role-r) |
+| EMPLOYMENT_TYPE | `et/` | [**employment_type**](#employment_type-et) |
+| EXPECTED_SALARY | `s/` | [**expected_salary**](#expected_salary-s) |
+| LEVEL_OF_EDUCATION | `l/` | [**level_of_education**](#level_of_education-l) |
+| YEARS_OF_EXPERIENCE | `y/` | [**years_of_experience**](#years_of_experience-y) |
+| TAG | `t/` | [**tag**](#tag-t) |
+| INTERVIEW | `i/` | [**interview**](#interview-i) |
+| NOTES | `nt/` | [**notes**](#notes-nt) |
 
 </div>
 
@@ -191,7 +191,7 @@ Examples:
 * `edit 1 t/` will remove all ***tags***s from the applicant with index number 1
 * `edit 1 n/John t/` will change the name of the applicant with index number 1 to `John` and remove all the applicant's ***tag***s
 
-<div markdown="block" class="alert alert-success">
+<div markdown="block" class="alert alert-secondary">
 **:information_source: Prefix inputs for `edit` command must follow the same input specifications as `add` command:**<br>
 
 * You may 
@@ -200,17 +200,17 @@ Examples:
 
 | Input | Prefix | Specifications |
 | :---: | :---: | :---: |
-| NAME | `n/` | [name](#name-n) |
-| PHONE_NUMBER | `p/` | [phone_number](#phone_number-p) |
-| EMAIL_ADDRESS | `e/` | [email_address](#email_address-e) |
-| ROLE | `r/` | [role](#role-r) |
-| EMPLOYMENT_TYPE | `et/` | [employment_type](#employment_type-et) |
-| EXPECTED_SALARY | `s/` | [expected_salary](#expected_salary-s) |
-| LEVEL_OF_EDUCATION | `l/` | [level_of_education](#level_of_education-l) |
-| YEARS_OF_EXPERIENCE | `y/` | [years_of_experience](#years_of_experience-y) |
-| TAG | `t/` | [tag](#tag-t) |
-| INTERVIEW | `i/` | [interview](#interview-i) |
-| NOTES | `nt/` | [notes](#notes-nt) |
+| NAME | `n/` | [**name**](#name-n) |
+| PHONE_NUMBER | `p/` | [**phone_number**](#phone_number-p) |
+| EMAIL_ADDRESS | `e/` | [**email_address**](#email_address-e) |
+| ROLE | `r/` | [**role**](#role-r) |
+| EMPLOYMENT_TYPE | `et/` | [**employment_type**](#employment_type-et) |
+| EXPECTED_SALARY | `s/` | [**expected_salary**](#expected_salary-s) |
+| LEVEL_OF_EDUCATION | `l/` | [**level_of_education**](#level_of_education-l) |
+| YEARS_OF_EXPERIENCE | `y/` | [**years_of_experience**](#years_of_experience-y) |
+| TAG | `t/` | [**tag**](#tag-t) |
+| INTERVIEW | `i/` | [**interview**](#interview-i) |
+| NOTES | `nt/` | [**notes**](#notes-nt) |
 
 </div>
 
@@ -238,7 +238,7 @@ Examples:
 * `find n/John Mary t/friend colleague`
 * `find n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 nt/has the credentials d/Not Done`
 
-<div markdown="block" class="alert alert-success">
+<div markdown="block" class="alert alert-secondary">
 **:information_source: Prefix inputs for `find` command must follow the following input specifications:**<br>
 
 * You may
@@ -247,17 +247,17 @@ Examples:
 
 | Input | Prefix | Specifications |
 | :---: | :---: | :---: |
-| NAME | `n/` | [name](#name-n-1) |
-| PHONE_NUMBER | `p/` | [phone_number](#phone_number-p-1) |
-| EMAIL_ADDRESS | `e/` | [email_address](#email_address-e-1) |
-| ROLE | `r/` | [role](#role-r-1) |
-| EMPLOYMENT_TYPE | `et/` | [employment_type](#employment_type-et-1) |
-| EXPECTED_SALARY | `s/` | [expected_salary](#expected_salary-s-1) |
-| LEVEL_OF_EDUCATION | `l/` | [level_of_education](#level_of_education-l-1) |
-| YEARS_OF_EXPERIENCE | `y/` | [years_of_experience](#years_of_experience-y-1) |
-| TAG | `t/` | [tag](#tag-t-1) |
-| INTERVIEW | `i/` | [interview](#interview-i-1) |
-| NOTES | `nt/` | [notes](#notes-nt-1) |
+| NAME | `n/` | [**name**](#name-n-1) |
+| PHONE_NUMBER | `p/` | [**phone_number**](#phone_number-p-1) |
+| EMAIL_ADDRESS | `e/` | [**email_address**](#email_address-e-1) |
+| ROLE | `r/` | [**role**](#role-r-1) |
+| EMPLOYMENT_TYPE | `et/` | [**employment_type**](#employment_type-et-1) |
+| EXPECTED_SALARY | `s/` | [**expected_salary**](#expected_salary-s-1) |
+| LEVEL_OF_EDUCATION | `l/` | [**level_of_education**](#level_of_education-l-1) |
+| YEARS_OF_EXPERIENCE | `y/` | [**years_of_experience**](#years_of_experience-y-1) |
+| TAG | `t/` | [**tag**](#tag-t-1) |
+| INTERVIEW | `i/` | [**interview**](#interview-i-1) |
+| NOTES | `nt/` | [**notes**](#notes-nt-1) |
 
 </div>
         

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -229,16 +229,20 @@ Format: `find [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMPLOYMEN
 * If you input multiple of the same prefix, **only the last** prefix will be used for the search of that category.
 * Input for each prefix can contain multiple **keywords** separated by whitespace, e.g. `n/John Mary`, `t/friend colleague`
 
-<div markdown="span" class="alert alert-warning">
+<div markdown="block" class="alert alert-warning">
+
 * You can search for tags using multiple keywords by providing your keywords separated by whitespace in a `t/` prefix. (i.e. `find t/smart kind`)
     * This is different from `add` and `edit` commands which require tag inputs to be provided separately. (i.e. `edit 1 t/smart t/kind`)
+
 </div>
 
 * Inputs for all prefixes are **case-insensitive**.
 
-<div markdown="span" class="alert alert-warning">
+<div markdown="block" class="alert alert-warning">
+
 * Applicants will not be filtered by prefixes that are not provided.
 * Applicants will also not be filtered by prefixes that are provided, yet have empty inputs. (i.e. `find d/` will return all applicants unfiltered by their ***done*** status)
+
 </div>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -23,6 +23,7 @@ descriptions of the usage of each component in RecruitIn under [Usages](#usages)
     + [Viewing help : `help`](#viewing-help--help)
     + [Adding an applicant: `add`](#adding-an-applicant-add)
       - [Prefix Input Specifications ***{Advanced}***:](#prefix-input-specifications-advanced)
+    + [Editing an applicant: `edit`](#editing-an-applicant--edit)
     + [Listing all applicants : `list`](#listing-all-applicants--list)
     + [Finding an applicant : `find`](#finding-an-applicant--find)
       - [Prefix Input Specifications ***{Advanced}***:](#prefix-input-specifications-advanced-1)
@@ -131,8 +132,11 @@ Adds an applicant to RecruitIn.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL_ADDRESS r/ROLE et/EMPLOYMENT_TYPE s/EXPECTED_SALARY l/LEVEL_OF_EDUCATION y/YEARS_OF_EXPERIENCE [t/TAG] [i/INTERVIEW] [nt/NOTES]​`
 
+* To add multiple tags, multiple `t/` prefixes should be used.
+
 Examples:
 * `add n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 i/2021-10-21, 20:00 nt/This applicant has the credentials needed for this job.`
+* `add n/John p/90909090 e/john@gmail.com r/Software Tester et/Full time s/4500 l/High School y/3 t/smart t/helpful` to add a person named `John` with two tags `smart` and `helpful`
 
 #### Prefix Input Specifications ***{Advanced}***:
 
@@ -205,17 +209,24 @@ Examples:
     * For example:
         * NOTES inputs such as `This candidate is good!` and `@Applicant123 is suitab13 for th3 job!` are acceptable.
 
-### Editing an applicants : `edit`
+### Editing an applicant : `edit`
 
-Edits an applicant's data in RecruitIn.
+Edits an applicant's with specified index in RecruitIn.
 
-Format: ```edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMPLOYMENT_TYPE]
- [s/EXPECTED_SALARY] [l/LEVEL_OF_EDUCATION] [y/YEARS_OF_EXPERIENCE] [t/TAG] [i/INTERVIEW] [nt/NOTES] ```
+Format: `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMPLOYMENT_TYPE]
+ [s/EXPECTED_SALARY] [l/LEVEL_OF_EDUCATION] [y/YEARS_OF_EXPERIENCE] [t/TAG] [i/INTERVIEW] [nt/NOTES]`
  
  * Edit command must take at least 1 prefix input.
- * If you input multiple of the same prefix, only the last prefix will be used for the search of that category.
- * Input for each prefix can contain multiple keywords separated by whitespace, e.g. n/John Mary, t/friend colleague
- * Inputs for all prefixes are case-insensitive.
+ * The `INDEX` refers to the index number shown in the displayed applicants list.
+ * For `t/` prefix in particular, if **only** a single tag prefix is provided like so `t/` with no values, it will erase
+remove tags from the applicant.
+   * **note** : Giving more than 1 tag prefix input with 1 or more having no value like so `t/ t/smart` will instead lead
+   to an error.
+
+Examples:
+* `edit 1 r/Software Engineer` will change the ***role*** of the applicant with the index number 1
+* `edit 1 t/` will remove all ***tags***s from the applicant with index number 1
+* `edit 1 n/John t/` will change the name of the applicant with index number 1 to `John` and remove all the applicant's ***tag***s
  
 #### Prefix Input Specifications ***{Advanced}***:
 
@@ -235,19 +246,19 @@ Format: ```edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/E
   * All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type-et).
 
 * ##### EXPECTED_SALARY `s/`
-   * All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary-s).
+  * All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary-s).
 
 * ##### LEVEL_OF_EDUCATION `l/`
   * All keywords provided as LEVEL_OF_EDUCATION input must comply with input specifications for add given [**here**](#level_of_education-l).
 
 * ##### YEARS_OF_EXPERIENCE `y/`
-    * All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience-y)..
+  * All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience-y)..
 
 * ##### TAG `t/`
-    * All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag-t).
+  * All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag-t).
 
 * ##### INTERVIEW `i/`
-    * All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview-i).
+  * All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview-i).
 
 ### Listing all applicants : `list`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -22,11 +22,9 @@ descriptions of the usage of each component in RecruitIn under [Usages](#usages)
   * [Features](#features)
     + [Viewing help : `help`](#viewing-help--help)
     + [Adding an applicant: `add`](#adding-an-applicant-add)
-      - [Prefix Input Specifications ***{Advanced}***:](#prefix-input-specifications-advanced)
     + [Editing an applicant: `edit`](#editing-an-applicant--edit)
     + [Listing all applicants : `list`](#listing-all-applicants--list)
     + [Finding an applicant : `find`](#finding-an-applicant--find)
-      - [Prefix Input Specifications ***{Advanced}***:](#prefix-input-specifications-advanced-1)
     + [Deleting an applicant : `delete`](#deleting-an-applicant--delete)
     + [Showing search terms : `show`](#showing-search-terms--show)
     + [Marking an applicant : `mark`](#marking-an-applicant--mark)
@@ -35,6 +33,7 @@ descriptions of the usage of each component in RecruitIn under [Usages](#usages)
     + [Exiting the program : `exit`](#exiting-the-program--exit)
     + [Saving the data](#saving-the-data)
     + [Editing the data file](#editing-the-data-file)
+  * [Prefix Input Specifications ***{Advanced}***](#prefix-input-specifications-advanced)
   * [FAQ](#faq)
   * [Command summary](#command-summary)
 
@@ -133,77 +132,78 @@ Adds an applicant to RecruitIn.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL_ADDRESS r/ROLE et/EMPLOYMENT_TYPE s/EXPECTED_SALARY l/LEVEL_OF_EDUCATION y/YEARS_OF_EXPERIENCE [t/TAG] [i/INTERVIEW] [nt/NOTES]​`
 
 * To add multiple tags, multiple `t/` prefixes should be used.
+* Refer to [Add Input Specifications](#add-inputs) for detailed input specifications.
 
 Examples:
 * `add n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 i/2021-10-21, 20:00 nt/This applicant has the credentials needed for this job.`
 * `add n/John p/90909090 e/john@gmail.com r/Software Tester et/Full time s/4500 l/High School y/3 t/smart t/helpful` to add a person named `John` with two tags `smart` and `helpful`
 
-#### Prefix Input Specifications ***{Advanced}***:
+#### Prefix Input Specifications:
 
 **Note**: **Alphanumeric** characters refers specifically to characters a-z, A-Z and 0-9.
 * ##### NAME `n/`
-  * A NAME should only contain alphanumeric characters. Spaces between words are allowed.
-  * For example:
-    * NAME inputs such as `John`, `Mary Sue` and `9ine 6ix` are acceptable.
-    * NAME inputs such as `J@hn`, `Mary S^e` and `B{}b` are not acceptable.
+    * A NAME should only contain alphanumeric characters. Spaces between words are allowed.
+    * For example:
+        * NAME inputs such as `John`, `Mary Sue` and `9ine 6ix` are acceptable.
+        * NAME inputs such as `J@hn`, `Mary S^e` and `B{}b` are not acceptable.
 * ##### PHONE_NUMBER `p/`
-  * A PHONE_NUMBER should contain a minimum of 3 digits. No characters other than the digits 0-9 are allowed.
-  * For example:
-    * PHONE_NUMBER inputs such as `99999999` and `999` are acceptable.
-    * PHONE_NUMBER inputs such as `9999 9999` and `88` are not acceptable.
+    * A PHONE_NUMBER should contain a minimum of 3 digits. No characters other than the digits 0-9 are allowed.
+    * For example:
+        * PHONE_NUMBER inputs such as `99999999` and `999` are acceptable.
+        * PHONE_NUMBER inputs such as `9999 9999` and `88` are not acceptable.
 * ##### EMAIL_ADDRESS `e/`
-  * An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.
-  * The **local part**:
-    * must contain **at least 1** alphanumeric character. 
-    * It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`
-    * It must **start with** and **end with** an alphanumeric character.
-  * The **domain part**:
-    * must contain **at least 2** alphanumeric characters.
-    * It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with
-    `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`
-  * For example:
-    * EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.
-    * EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.
+    * An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.
+    * The **local part**:
+        * must contain **at least 1** alphanumeric character.
+        * It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`
+        * It must **start with** and **end with** an alphanumeric character.
+    * The **domain part**:
+        * must contain **at least 2** alphanumeric characters.
+        * It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with
+          `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`
+    * For example:
+        * EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.
+        * EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.
 * ##### ROLE `r/`
-  * A ROLE should only contain **alphanumeric** characters. Spaces between words are allowed.
-  * For example:
-    * ROLE inputs such as `Software Engineer` and `Sales Assistant` are acceptable.
-    * ROLE inputs such as `Softw@re Engin^^r` and `Day + Night Security Guard` are not acceptable.
+    * A ROLE should only contain **alphanumeric** characters. Spaces between words are allowed.
+    * For example:
+        * ROLE inputs such as `Software Engineer` and `Sales Assistant` are acceptable.
+        * ROLE inputs such as `Softw@re Engin^^r` and `Day + Night Security Guard` are not acceptable.
 * ##### EMPLOYMENT_TYPE `et/`
-  * An EMPLOYMENT_TYPE should be one of the following: `Full time`, `Part time`, `Temporary` or `Internship`.
-  * An EMPLOYMENT_TYPE is **case-insensitive**.
-  * For example:
-    * EMPLOYMENT_TYPE inputs such as `Full time` and `Internship` are acceptable.
-    * EMPLOYMENT_TYPE inputs such as `fUlL tiMe` and `iNtErnShIP` are acceptable.
-    * EMPLOYMENT_TYPE inputs such as `Long term` are not acceptable.
+    * An EMPLOYMENT_TYPE should be one of the following: `Full time`, `Part time`, `Temporary` or `Internship`.
+    * An EMPLOYMENT_TYPE is **case-insensitive**.
+    * For example:
+        * EMPLOYMENT_TYPE inputs such as `Full time` and `Internship` are acceptable.
+        * EMPLOYMENT_TYPE inputs such as `fUlL tiMe` and `iNtErnShIP` are acceptable.
+        * EMPLOYMENT_TYPE inputs such as `Long term` are not acceptable.
 * ##### EXPECTED_SALARY `s/`
-  * An EXPECTED_SALARY should only represent non-negative integers.
-    * Non-negative integers range from 0 to 2^(31) - 1 inclusive.
-  * For example:
-    * EXPECTED_SALARY inputs such as `0` and `3500` are acceptable.
-    * EXPECTED_SALARY inputs such as `-600` and `~350` are not acceptable.
+    * An EXPECTED_SALARY should only represent non-negative integers.
+        * Non-negative integers range from 0 to 2^(31) - 1 inclusive.
+    * For example:
+        * EXPECTED_SALARY inputs such as `0` and `3500` are acceptable.
+        * EXPECTED_SALARY inputs such as `-600` and `~350` are not acceptable.
 * ##### LEVEL_OF_EDUCATION `l/`
-  * A LEVEL_OF_EDUCATION should be one of the following: `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` or `PhD`.
-  * A LEVEL_OF_EDUCATION is **case-insensitive**.
-  * For example:
-    * LEVEL_OF_EDUCATION inputs such as `Middle School` and `PhD` are acceptable.
-    * LEVEL_OF_EDUCATION inputs such as `miDDlE scHoOL` and `phD` are acceptable.
-    * LEVEL_OF_EDUCATION inputs such as `Kindergarten` are not acceptable.
+    * A LEVEL_OF_EDUCATION should be one of the following: `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` or `PhD`.
+    * A LEVEL_OF_EDUCATION is **case-insensitive**.
+    * For example:
+        * LEVEL_OF_EDUCATION inputs such as `Middle School` and `PhD` are acceptable.
+        * LEVEL_OF_EDUCATION inputs such as `miDDlE scHoOL` and `phD` are acceptable.
+        * LEVEL_OF_EDUCATION inputs such as `Kindergarten` are not acceptable.
 * ##### YEARS_OF_EXPERIENCE `y/`
-  * A YEARS_OF_EXPERIENCE should be a **non-negative integer** smaller than or equals to **67** (re-employment age in Singapore).
-  * For example:
-    * YEARS_OF_EXPERIENCE inputs such as `0` and `10` are acceptable.
-    * YEARS_OF_EXPERIENCE inputs such as `-1`, `3.5`, and `100` are not acceptable.
+    * A YEARS_OF_EXPERIENCE should be a **non-negative integer** smaller than or equals to **67** (re-employment age in Singapore).
+    * For example:
+        * YEARS_OF_EXPERIENCE inputs such as `0` and `10` are acceptable.
+        * YEARS_OF_EXPERIENCE inputs such as `-1`, `3.5`, and `100` are not acceptable.
 * ##### TAG `t/`
-  * A TAG should only contain alphanumeric characters. Spaces between words are **not** allowed.
-  * For example:
-    * TAG inputs such as `friends` and `colleagues` are allowed.
-    * TAG inputs such as `best friends`, `old colleagues` and `seni@r` are not allowed.
+    * A TAG should only contain alphanumeric characters. Spaces between words are **not** allowed.
+    * For example:
+        * TAG inputs such as `friends` and `colleagues` are allowed.
+        * TAG inputs such as `best friends`, `old colleagues` and `seni@r` are not allowed.
 * ##### INTERVIEW `i/`
-  * An INTERVIEW should follow the DateTime format `yyyy-MM-dd, H:mm`.
-  * For example: 
-    * INTERVIEW inputs such as `2021-10-22, 13:00` and `2022-01-30, 3:00` are acceptable.
-    * INTERVIEW inputs such as `morning`, `2021.10.21` and `2021-10-22 13:00` are not acceptable. 
+    * An INTERVIEW should follow the DateTime format `yyyy-MM-dd, H:mm`.
+    * For example:
+        * INTERVIEW inputs such as `2021-10-22, 13:00` and `2022-01-30, 3:00` are acceptable.
+        * INTERVIEW inputs such as `morning`, `2021.10.21` and `2021-10-22 13:00` are not acceptable.
 * ##### NOTES `nt/`
     * A NOTES can contain any character, number or symbol as there are no restrictions in place.
     * For example:
@@ -222,13 +222,15 @@ Format: `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMP
 remove tags from the applicant.
    * **note** : Giving more than 1 tag prefix input with 1 or more having no value like so `t/ t/smart` will instead lead
    to an error.
+ * Prefix inputs for `edit` command must follow the same input specifications as `add` command. 
+Refer to [Add Input Specifications](#add-inputs) for detailed input specifications.
 
 Examples:
 * `edit 1 r/Software Engineer` will change the ***role*** of the applicant with the index number 1
 * `edit 1 t/` will remove all ***tags***s from the applicant with index number 1
 * `edit 1 n/John t/` will change the name of the applicant with index number 1 to `John` and remove all the applicant's ***tag***s
  
-#### Prefix Input Specifications ***{Advanced}***:
+#### Prefix Input Specifications:
 
 * ##### NAME `n/`
   * All keywords provided as NAME input must comply with input specifications for add given [**here**](#name-n).
@@ -276,6 +278,7 @@ Format: `find [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMPLOYMEN
 * If you input multiple of the same prefix, **only the last** prefix will be used for the search of that category.
 * Input for each prefix can contain multiple **keywords** separated by whitespace, e.g. `n/John Mary`, `t/friend colleague`
 * Inputs for all prefixes are **case-insensitive**.
+* Refer to [Find Input Specifications](#find-inputs) for detailed input specifications.
 
 Examples:
 * `find n/John Mary` finds all applicants with either `John` or `Mary` as values for name prefix.
@@ -284,7 +287,7 @@ Examples:
 * `find n/John Mary t/friend colleague`
 * `find n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 nt/has the credentials d/Not Done`
 
-#### Prefix Input Specifications ***{Advanced}***:
+#### Prefix Input Specifications:
 
 * ##### NAME `n/`
   * A NAME is considered matching with a ***Name*** only if **at least 1** keyword is equal to **at least 1** word in the ***Name***.
@@ -300,7 +303,6 @@ Examples:
     * A `99999999` input can only match with *Contact Number*s that are `99999999`.
     * A `99999999 88888888` input can only match with *Contact Number*s that are `99999999` and `88888888`.
 
-
 * ##### EMAIL_ADDRESS `e/`
   * An EMAIL_ADDRESS is considered matching with an ***Email Address*** only if **at least 1** keyword is equal to **at least 1** word in the ***Email Address***.
   * All keywords provided as EMAIL_ADDRESS input must comply with input specifications for add given [**here**](#email_address-e).
@@ -308,7 +310,6 @@ Examples:
     * A `alexyeoh@example.com` input can match with *Email*s such as `alexyeoh@example.com`.
     * A `alexyeoh@example.com marysue@gmail.com` input can match with *Email*s such as `alexyeoh@example.com`
 and `marysue@gmail.com`.
-
 
 * ##### ROLE `r/`
   * A ROLE is considered matching with a ***Role*** only if **each of every** provided keyword is equal to **at least 1** word in the ***Role***.
@@ -318,9 +319,8 @@ and `marysue@gmail.com`.
     * A `Software Engineer` input can match with *Role*s such as `Software Engineer` or `Senior Software Engineer`
 but not with *Role*s such as `Software` or `Software Developer`.
 
-
 * ##### EMPLOYMENT_TYPE `et/`
-  * An EMPLOYMENT_TYPE is considered matching with an ***Employment Type*** only if it **starts with any** of the keywords in the ***Employment Type**.
+  * An EMPLOYMENT_TYPE is considered matching with an ***Employment Type*** only if it **starts with any** of the keywords in the ***Employment Type***.
   * All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type-et).
   * For example:
     * A `Full time` or `full time` or `full` input will match only with *Employment Type*s that are ```Full time```
@@ -329,14 +329,12 @@ but not with *Role*s such as `Software` or `Software Developer`.
     * A ```full time bob``` input will throw an exception as ```bob``` is not a term any of the *Employment Type*s start
     with.
 
-
 * ##### EXPECTED_SALARY `s/`
     * An EXPECTED_SALARY is considered matching with a ***Expected Salary*** only if **at least 1** keyword is within a range of `500` from **at least 1** keyword in the ***Expected Salary***.
     * All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary-s).
     * For example:
         * A `3000` input can match with *Expected Salary*s that range from `2500` to `3500` inclusive.
         * A `2500 5000` input can match with *Expected Salary*s from the ranges `2000` to `3000` inclusive, and `4500` to `5500` inclusive.
-
 
 * ##### LEVEL_OF_EDUCATION `l/`
   * LEVEL_OF_EDUCATION can be a fixed number of levels, being `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` and `PhD`.
@@ -346,14 +344,12 @@ but not with *Role*s such as `Software` or `Software Developer`.
     * A `H` input can match with ***Level of Education***s such `High School`, but not with *Level of Education*s such as `PhD`
     * A `High School` input can match with ***Level of Education***s such as `High School`, but not with *Level of Education*s such as `Middle School`
 
-
 * ##### YEARS_OF_EXPERIENCE `y/`
     * A YEARS_OF_EXPERIENCE is considered matching with a ***Years Of Experience*** only if the value represented by **at least 1** keyword is larger than or equal to the value represented by the ***Years Of Experience***.
     * All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience-y).
     * For example:
         * A `3` input can match with ***Year Of Experience***s that are higher than or equal to 3.
         * A `2 3` input can match with ***Year Of Experience***s that are higher than or equal to 2.
-
 
 * ##### TAG `t/`
     * Each applicant can have many stored tags, so ***Tags*** will be used to refer to each applicant's stored ***Tag***s.
@@ -362,7 +358,6 @@ but not with *Role*s such as `Software` or `Software Developer`.
     * For example:
         * An `old` input can match with applicants that have the ***Tag*** `old`
         * An `experienced old` input can match with applicants that have the ***Tag*** `experienced`, or `old`, or both.
-
 
 * ##### INTERVIEW `i/`
     * An INTERVIEW is considered matching with a ***Interview*** only if the ***Interview***'s time string contains **at least 1** keyword.
@@ -526,6 +521,50 @@ Example of format of data for one applicant in applicants:
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
 If your changes to the data file makes its format invalid, RecruitIn will discard all data and start with an empty data file at the next run.
 </div>
+
+--------------------------------------------------------------------------------------------------------------------
+
+## Prefix Input Specifications ***{Advanced}***
+
+### Add Inputs
+
+**Note**: **Alphanumeric** characters refers specifically to characters a-z, A-Z and 0-9.
+
+| Input | Prefix |  Specifications |
+| :---: | :---: | --- |
+| <h4 id="name">NAME</h4> | `n/` | <ul><li>A NAME should only contain alphanumeric characters. Spaces between words are allowed.</li><li>For example:</li><ul><li>NAME inputs such as `John`, `Mary Sue` and `9ine 6ix` are acceptable.</li><li>NAME inputs such as `J@hn`, `Mary S^e` and `B{}b` are not acceptable.</li></ul></ul> |
+| <h4 id="phone_number">PHONE_NUMBER</h4> | `p/` | <ul><li>A PHONE_NUMBER should contain a minimum of 3 digits. No characters other than the digits 0-9 are allowed.</li><li>For example:</li><ul><li>PHONE_NUMBER inputs such as `99999999` and `999` are acceptable.</li><li>PHONE_NUMBER inputs such as `9999 9999` and `88` are not acceptable.</li></ul></ul> |
+| <h4 id="email_address">EMAIL_ADDRESS</h4> | `e/` | <ul><li>An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.</li><li>The **local part**:</li><ul><li>must contain **at least 1** alphanumeric character.</li><li>It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`</li><li>It must **start with** and **end with** an alphanumeric character.</li></ul><li>The **domain part**:</li><ul><li>must contain **at least 2** alphanumeric characters.</li><li>It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`</li></ul><li>For example:</li><ul><li>EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.</li><li>EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.</li></ul></ul> |
+| <h4 id="role">ROLE</h4> | `r/` | <ul><li>A ROLE should only contain **alphanumeric** characters. Spaces between words are allowed.</li><li>For example:</li><ul><li>ROLE inputs such as `Software Engineer` and `Sales Assistant` are acceptable.</li><li>ROLE inputs such as `Softw@re Engin^^r` and `Day + Night Security Guard` are not acceptable.</li></ul></ul> |
+| <h4 id="employment_type">EMPLOYMENT_TYPE</h4> | `et/` | <ul><li>An EMPLOYMENT_TYPE should be one of the following: `Full time`, `Part time`, `Temporary` or `Internship`.</li><li>For example</li><ul><li>EMPLOYMENT_TYPE inputs such as `Full time` and `Internship` are acceptable.</li><li>EMPLOYMENT_TYPE inputs such as `fUlL tiMe` and `iNtErnShIP` are acceptable.</li><li>EMPLOYMENT_TYPE inputs such as `Long term` are not acceptable.</li></ul></ul> |
+| <h4 id="expected_salary">EXPECTED_SALARY</h4> | `s/` | <ul><li>An EXPECTED_SALARY should only represent non-negative integers.</li><ul><li>Non-negative integers range from 0 to 2^(31) - 1 inclusive.</li></ul><li>For example:</li><ul><li>EXPECTED_SALARY inputs such as `0` and `3500` are acceptable.</li><li>EXPECTED_SALARY inputs such as `-600` and `~350` are not acceptable.</li></ul></ul> |
+| <h4 id="level_of_education">LEVEL_OF_EDUCATION</h4> | `l/` | <ul><li>A LEVEL_OF_EDUCATION should be one of the following: `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` or `PhD`. </li><li>A LEVEL_OF_EDUCATION is **case-insensitive**.</li><li>For example:</li><ul><li>LEVEL_OF_EDUCATION inputs such as `Middle School` and `PhD` are acceptable.</li><li>LEVEL_OF_EDUCATION inputs such as `miDDlE scHoOL` and `phD` are acceptable.</li><li>LEVEL_OF_EDUCATION inputs such as `Kindergarten` are not acceptable.</li></ul></ul> |
+| <h4>YEARS_OF_EXPERIENCE</h4> | `y/` | <ul><li>A YEARS_OF_EXPERIENCE should be a **non-negative integer** smaller than or equals to **67** (re-employment age in Singapore).</li><li>For example:</li><ul><li>YEARS_OF_EXPERIENCE inputs such as `0` and `10` are acceptable.</li><li>YEARS_OF_EXPERIENCE inputs such as `-1`, `3.5`, and `100` are not acceptable.</li></ul></ul> |
+| <h4 id="tag">TAG</h4> | `t/` | <ul><li>A TAG should only contain alphanumeric characters. Spaces between words are **not** allowed.</li><li>For example:</li><ul><li>TAG inputs such as `friends` and `colleagues` are allowed.</li><li>TAG inputs such as `best friends`, `old colleagues` and `seni@r` are not allowed.</li></ul></ul> |
+| <h4 id="interview">INTERVIEW</h4> | `i/` | <ul><li>An INTERVIEW should follow the DateTime format `yyyy-MM-dd, H:mm`.</li><li>For example:</li><ul><li>INTERVIEW inputs such as `2021-10-22, 13:00` and `2022-01-30, 3:00` are acceptable.</li><li>INTERVIEW inputs such as `morning`, `2021.10.21` and `2021-10-22 13:00` are not acceptable.</li></ul></ul> |
+| <h4 id="notes">NOTES</h4> | `nt/` | <ul><li>A NOTES can contain any character, number or symbol as there are no restrictions in place.</li><li>For example:</li><ul><li>NOTES inputs such as `This candidate is good!` and `@Applicant123 is suitab13 for th3 job!` are acceptable.</li></ul></ul> |
+
+* Return to [Add](#adding-an-applicant-add).
+* Return to [Edit](#editing-an-applicant--edit).
+
+### Find Inputs
+
+| Input | Prefix | Specifications |
+| :---: | :---: | --- |
+| NAME | `n/` | <ul><li>A NAME is considered matching with a ***Name*** only if **at least 1** keyword is equal to **at least 1** word in the ***Name***.</li><li>All keywords provided as NAME input must comply with input specifications for add given [**here**](#name)</li><li>For example:</li><ul><li>A `John` input can match with ***Name*** s such as `John Tan` or `John Lee`.</li><li>A `John Mary` input can match with ***Name*** s such as `Mary John`, `Mary Lee` or `Long John`.</li></ul></ul> |
+| PHONE_NUMBER | `p/` | <ul><li>A PHONE_NUMBER is considered matching with a ***Phone Number*** only if **at least 1** keyword is equal to **at least 1** word in the ***Phone Number***</li><li>All keywords provided as PHONE_NUMBER input must comply with input specifications for add given [**here**](#phone_number)</li><li>For example:</li><ul><li>A `99999999` input can only match with ***Phone Number*** s that are `99999999`.</li><li>A `99999999 88888888` input can only match with ***Phone Number*** s that are `99999999` and `88888888`.</li></ul></ul> |
+| EMAIL_ADDRESS | `e/` | <ul><li>An EMAIL_ADDRESS is considered matching with an ***Email Address*** only if **at least 1** keyword is equal to **at least 1** word in the ***Email Address***.</li><li>All keywords provided as EMAIL_ADDRESS input must comply with input specifications for add given [**here**](#email_address)</li><li>For example:</li><ul><li>A `alexyeoh@example.com` input can match with ***Email*** s such as `alexyeoh@example.com`.</li><li>A `alexyeoh@example.com marysue@gmail.com` input can match with ***Email*** s such as `alexyeoh@example.com` and `marysue@gmail.com`.</li></ul></ul> |
+| ROLE | `r/` | <ul><li>A ROLE is considered matching with a ***Role*** only if **each of every** provided keyword is equal to **at least 1** word in the ***Role***.</li><li>All keywords provided as ROLE input must comply with input specifications for add given [**here**](#role)</li><li>For example:</li><ul><li>A `Software` input can match with *Role*s such as `Software Engineer`, `Software` or `Software Developer`.</li><li>A `Software Engineer` input can match with ***Role*** s such as `Software Engineer` or `Senior Software Engineer` but not with ***Role*** s such as `Software` or `Software Developer`.</li></ul></ul> |
+| EMPLOYMENT_TYPE | `et/` | <ul><li>An EMPLOYMENT_TYPE is considered matching with an ***Employment Type*** only if it **starts with any** of the keywords in the ***Employment Type***.</li><li>All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type)</li><li>For example:</li><ul><li>A `Full time` or `full time` or `full` input will match only with ***Employment Type*** s that are `Full time`</li><li>A `Full part` input will match with all ***Employment Type*** s that are `Full time` or `Part time`</li><li>A `temp Intern` input will match with all ***Employment Type*** s that are `Temporary` or `Internship`</li><li>A `full time bob` input will throw an exception as `bob` is not a term any of the ***Employment Type*** s start with.</li></ul></ul> |
+| EXPECTED_SALARY | `s/` | <ul><li>An EXPECTED_SALARY is considered matching with a ***Expected Salary*** only if **at least 1** keyword is within a range of `500` from **at least 1** keyword in the ***Expected Salary***.</li><li>All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary)</li><li>For example:</li><ul><li>A `3000` input can match with ***Expected Salary*** s that range from `2500` to `3500` inclusive.</li><li>A `2500 5000` input can match with ***Expected Salary*** s from the ranges `2000` to `3000` inclusive, and `4500` to `5500` inclusive.</li></ul></ul> |
+|LEVEL_OF_EDUCATION | `l/` | <ul><li>LEVEL_OF_EDUCATION can be a fixed number of levels, being `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` and `PhD`. </li><li>A LEVEL_OF_EDUCATION is considered matching with a ***level of Education*** only if **at least 1** letter of a keyword is equal to **at least 1** letter in the ***Level of Education***.</li><li>All keywords provided as LEVEL_OF_EDUCATION input must comply with input specifications for add given [**here**](#level_of_education)</li><li>For example:</li><ul><li>A `H` input can match with ***Level of Education*** s such `High School`, but not with ***Level of Education*** s such as `PhD`</li><li>A `High School` input can match with ***Level of Education*** s such as `High School`, but not with ***Level of Education*** s such as `Middle School` </li></ul></ul> |
+| YEARS_OF_EXPERIENCE | `y/` | <ul><li>A YEARS_OF_EXPERIENCE is considered matching with a ***Years Of Experience*** only if the value represented by **at least 1** keyword is larger than or equal to the value represented by the ***Years Of Experience***.</li><li>All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience)</li><li>For example:</li><ul><li>A `3` input can match with ***Year Of Experience*** s that are higher than or equal to 3.</li><li>A `2 3` input can match with ***Year Of Experience*** s that are higher than or equal to 2.</li></ul></ul> |
+| TAG | `t/` | <ul><li>Each applicant can have many stored tags, so ***Tags*** will be used to refer to each applicant's stored ***Tag*** s.</li><li>A TAG is considered matching with a ***Tags*** only if ***at least 1*** keyword is **exactly equals** to **at least 1** ***Tag*** within the ***Tags***..</li><li>All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag)</li><li>For example:</li><ul><li>An `old` input can match with applicants that have the ***Tag*** `old`</li><li>An `experienced old` input can match with applicants that have the ***Tag*** `experienced`, or `old`, or both.</li></ul><ul> |
+| INTERVIEW | `i/` | <ul><li>An INTERVIEW is considered matching with a ***Interview*** only if the ***Interview***'s time string contains **at least 1** keyword.</li><li>All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview)</li><li>For example:</li><ul><li>A `2021` input can match with applicants that have the ***Interview*** in year 2021.</li><li>A `20:21` input can match with applicants that have the ***Interview*** at time 20:21 on any date.</li><li>A `21` input can match with ***Interviews*** `2021-10-10, 10:00`, `2020-10-21, 10:00`, `2020-10-10, 21:00` or `2020-10-10, 10:21`.</li></ul><ul> |
+| NOTES | `nt/` | <ul><li>NOTES are considered matching with  ***Notes*** only if  ***Notes*** contains **the entire** keyword.</li><li>All keywords provided as NOTES input must comply with input specifications for add given [**here**](#notes)</li><li>For example:</li><ul><li>A `good in this field` input can match with applicants that have ***Notes*** containing the `good in this field`.</li><li>A `passionate` input can match with applicants that have Notes such as `passionate but inexperienced` and `passionate and experienced`.</li></ul></ul> |
+| DONE | `d/` | <ul><li>An DONE is considered matching with a ***Done*** only if the ***Done***'s status string is either `Done` or `Not Done`.</li><li>For example:</li><ul><li>A `Done` input can match with applicants that have their ***Done*** status marked as Done.</li><li>A `Not Done` input can match with applicants that have their *Done* status unmarked as Not Done.</li></ul></ul> |
+
+* Return to [Find](#finding-an-applicant--find)
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,7 +132,7 @@ Adds an applicant to RecruitIn.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL_ADDRESS r/ROLE et/EMPLOYMENT_TYPE s/EXPECTED_SALARY l/LEVEL_OF_EDUCATION y/YEARS_OF_EXPERIENCE [t/TAG] [i/INTERVIEW] [nt/NOTES]​`
 
 * To add multiple tags, multiple `t/` prefixes should be used.
-* Refer to [Add Input Specifications](#add-inputs) for detailed input specifications.
+* Refer to [**Add Input Specifications**](#add-inputs) for detailed input specifications.
 
 Examples:
 * `add n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 i/2021-10-21, 20:00 nt/This applicant has the credentials needed for this job.`
@@ -152,7 +152,7 @@ remove tags from the applicant.
    * **note** : Giving more than 1 tag prefix input with 1 or more having no value like so `t/ t/smart` will instead lead
    to an error.
  * Prefix inputs for `edit` command must follow the same input specifications as `add` command. 
-Refer to [Add Input Specifications](#add-inputs) for detailed input specifications.
+Refer to [**Add Input Specifications**](#add-inputs) for detailed input specifications.
 
 Examples:
 * `edit 1 r/Software Engineer` will change the ***role*** of the applicant with the index number 1
@@ -175,7 +175,7 @@ Format: `find [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMPLOYMEN
 * If you input multiple of the same prefix, **only the last** prefix will be used for the search of that category.
 * Input for each prefix can contain multiple **keywords** separated by whitespace, e.g. `n/John Mary`, `t/friend colleague`
 * Inputs for all prefixes are **case-insensitive**.
-* Refer to [Find Input Specifications](#find-inputs) for detailed input specifications.
+* Refer to [**Find Input Specifications**](#find-inputs) for detailed input specifications.
 
 Examples:
 * `find n/John Mary` finds all applicants with either `John` or `Mary` as values for name prefix.
@@ -334,8 +334,8 @@ If your changes to the data file makes its format invalid, RecruitIn will discar
 
 ### Add Inputs
 
-* Return to [Add](#adding-an-applicant-add).
-* Return to [Edit](#editing-an-applicant--edit).
+* Return to [**Add**](#adding-an-applicant-add).
+* Return to [**Edit**](#editing-an-applicant--edit).
 
 * ##### NAME `n/`
     * A NAME should only contain alphanumeric characters. Spaces between words are allowed.
@@ -407,7 +407,7 @@ If your changes to the data file makes its format invalid, RecruitIn will discar
 
 ### Find Inputs
 
-* Return to [Find](#finding-an-applicant--find)
+* Return to [**Find**](#finding-an-applicant--find)
 
 * ##### NAME `n/`
     * A NAME is considered matching with a ***Name*** only if **at least 1** keyword is equal to **at least 1** word in the ***Name***.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,6 +132,10 @@ Adds an applicant to RecruitIn.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL_ADDRESS r/ROLE et/EMPLOYMENT_TYPE s/EXPECTED_SALARY l/LEVEL_OF_EDUCATION y/YEARS_OF_EXPERIENCE [t/TAG] [i/INTERVIEW] [nt/NOTES]​`
 
 * To add multiple tags, multiple `t/` prefixes should be used.
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+Providing multiple tag values in a single `t/` prefix will lead to an error. (i.e. `add n/John p/90909090 e/john@gmail.com r/Software Tester et/Full time s/4500 l/High School y/3 t/smart helpful` will lead to an error)
+</div>
+* Inputs for each prefix is taken as a single value. (i.e. `r/software engineer` has the value `software engineer`)
 * Refer to [**Add Input Specifications**](#add-inputs) for detailed input specifications.
 
 Examples:
@@ -149,8 +153,10 @@ Format: `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL_ADDRESS] [r/ROLE] [et/EMP
  * The `INDEX` refers to the index number shown in the displayed applicants list.
  * For `t/` prefix in particular, if **only** a single tag prefix is provided like so `t/` with no values, it will erase
 remove tags from the applicant.
-   * **note** : Giving more than 1 tag prefix input with 1 or more having no value like so `t/ t/smart` will instead lead
-   to an error.
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+Giving more than 1 tag prefix input with 1 or more having no value will instead lead to an error. (i.e. `edit 1 t/ t/smart` leads to an error)
+</div>
+ * Inputs for each prefix is taken as a single value. (i.e. `r/software engineer` has the value `software engineer`)
  * Prefix inputs for `edit` command must follow the same input specifications as `add` command. 
 Refer to [**Add Input Specifications**](#add-inputs) for detailed input specifications.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -417,6 +417,7 @@ Format: `delete INDEX...`
 * At least one `INDEX` must be given. (i.e. `delete ` is not a valid command)
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
 * `INDEX` uses **1-based indexing**.
+* Duplicate `INDEX`s are not allowed. (i.e. `delete 2 2` is not a valid command)
 * `INDEX` should not exceed the total number of applicants in the displayed applicants list.
 
 Examples:
@@ -451,6 +452,7 @@ Format: `mark INDEX…​`
 * At least one `INDEX` must be given. (i.e. `mark ` is not a valid command)
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
 * `INDEX` uses **1-based indexing**.
+* Duplicate `INDEX`s are not allowed. (i.e. `mark 2 2` is not a valid command)
 * `INDEX` should not exceed the total number of applicants in the displayed applicants list.
 
 Examples:
@@ -469,6 +471,7 @@ Format: `unmark INDEX…​`
 * At least one `INDEX` must be given. (i.e. `unmark ` is not a valid command)
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
 * `INDEX` uses **1-based indexing**.
+* Duplicate `INDEX`s are not allowed. (i.e. `delete 2 2` is not a valid command)
 * `INDEX` should not exceed the total number of applicants in the displayed applicants list.
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -138,77 +138,6 @@ Examples:
 * `add n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 i/2021-10-21, 20:00 nt/This applicant has the credentials needed for this job.`
 * `add n/John p/90909090 e/john@gmail.com r/Software Tester et/Full time s/4500 l/High School y/3 t/smart t/helpful` to add a person named `John` with two tags `smart` and `helpful`
 
-#### Prefix Input Specifications:
-
-**Note**: **Alphanumeric** characters refers specifically to characters a-z, A-Z and 0-9.
-* ##### NAME `n/`
-    * A NAME should only contain alphanumeric characters. Spaces between words are allowed.
-    * For example:
-        * NAME inputs such as `John`, `Mary Sue` and `9ine 6ix` are acceptable.
-        * NAME inputs such as `J@hn`, `Mary S^e` and `B{}b` are not acceptable.
-* ##### PHONE_NUMBER `p/`
-    * A PHONE_NUMBER should contain a minimum of 3 digits. No characters other than the digits 0-9 are allowed.
-    * For example:
-        * PHONE_NUMBER inputs such as `99999999` and `999` are acceptable.
-        * PHONE_NUMBER inputs such as `9999 9999` and `88` are not acceptable.
-* ##### EMAIL_ADDRESS `e/`
-    * An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.
-    * The **local part**:
-        * must contain **at least 1** alphanumeric character.
-        * It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`
-        * It must **start with** and **end with** an alphanumeric character.
-    * The **domain part**:
-        * must contain **at least 2** alphanumeric characters.
-        * It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with
-          `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`
-    * For example:
-        * EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.
-        * EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.
-* ##### ROLE `r/`
-    * A ROLE should only contain **alphanumeric** characters. Spaces between words are allowed.
-    * For example:
-        * ROLE inputs such as `Software Engineer` and `Sales Assistant` are acceptable.
-        * ROLE inputs such as `Softw@re Engin^^r` and `Day + Night Security Guard` are not acceptable.
-* ##### EMPLOYMENT_TYPE `et/`
-    * An EMPLOYMENT_TYPE should be one of the following: `Full time`, `Part time`, `Temporary` or `Internship`.
-    * An EMPLOYMENT_TYPE is **case-insensitive**.
-    * For example:
-        * EMPLOYMENT_TYPE inputs such as `Full time` and `Internship` are acceptable.
-        * EMPLOYMENT_TYPE inputs such as `fUlL tiMe` and `iNtErnShIP` are acceptable.
-        * EMPLOYMENT_TYPE inputs such as `Long term` are not acceptable.
-* ##### EXPECTED_SALARY `s/`
-    * An EXPECTED_SALARY should only represent non-negative integers.
-        * Non-negative integers range from 0 to 2^(31) - 1 inclusive.
-    * For example:
-        * EXPECTED_SALARY inputs such as `0` and `3500` are acceptable.
-        * EXPECTED_SALARY inputs such as `-600` and `~350` are not acceptable.
-* ##### LEVEL_OF_EDUCATION `l/`
-    * A LEVEL_OF_EDUCATION should be one of the following: `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` or `PhD`.
-    * A LEVEL_OF_EDUCATION is **case-insensitive**.
-    * For example:
-        * LEVEL_OF_EDUCATION inputs such as `Middle School` and `PhD` are acceptable.
-        * LEVEL_OF_EDUCATION inputs such as `miDDlE scHoOL` and `phD` are acceptable.
-        * LEVEL_OF_EDUCATION inputs such as `Kindergarten` are not acceptable.
-* ##### YEARS_OF_EXPERIENCE `y/`
-    * A YEARS_OF_EXPERIENCE should be a **non-negative integer** smaller than or equals to **67** (re-employment age in Singapore).
-    * For example:
-        * YEARS_OF_EXPERIENCE inputs such as `0` and `10` are acceptable.
-        * YEARS_OF_EXPERIENCE inputs such as `-1`, `3.5`, and `100` are not acceptable.
-* ##### TAG `t/`
-    * A TAG should only contain alphanumeric characters. Spaces between words are **not** allowed.
-    * For example:
-        * TAG inputs such as `friends` and `colleagues` are allowed.
-        * TAG inputs such as `best friends`, `old colleagues` and `seni@r` are not allowed.
-* ##### INTERVIEW `i/`
-    * An INTERVIEW should follow the DateTime format `yyyy-MM-dd, H:mm`.
-    * For example:
-        * INTERVIEW inputs such as `2021-10-22, 13:00` and `2022-01-30, 3:00` are acceptable.
-        * INTERVIEW inputs such as `morning`, `2021.10.21` and `2021-10-22 13:00` are not acceptable.
-* ##### NOTES `nt/`
-    * A NOTES can contain any character, number or symbol as there are no restrictions in place.
-    * For example:
-        * NOTES inputs such as `This candidate is good!` and `@Applicant123 is suitab13 for th3 job!` are acceptable.
-
 ### Editing an applicant : `edit`
 
 Edits an applicant's with specified index in RecruitIn.
@@ -229,38 +158,6 @@ Examples:
 * `edit 1 r/Software Engineer` will change the ***role*** of the applicant with the index number 1
 * `edit 1 t/` will remove all ***tags***s from the applicant with index number 1
 * `edit 1 n/John t/` will change the name of the applicant with index number 1 to `John` and remove all the applicant's ***tag***s
- 
-#### Prefix Input Specifications:
-
-* ##### NAME `n/`
-  * All keywords provided as NAME input must comply with input specifications for add given [**here**](#name-n).
-
-* ##### PHONE_NUMBER `p/`
-  * All keywords provided as PHONE_NUMBER input must comply with input specifications for add given [**here**](#phone_number-p).
-
-* ##### EMAIL_ADDRESS `e/`
-  * All keywords provided as EMAIL_ADDRESS input must comply with input specifications for add given [**here**](#email_address-e).
-
-* ##### ROLE `r/`
-  * All keywords provided as ROLE input must comply with input specifications for add given [**here**](#role-r).
- 
-* ##### EMPLOYMENT_TYPE `et/`
-  * All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type-et).
-
-* ##### EXPECTED_SALARY `s/`
-  * All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary-s).
-
-* ##### LEVEL_OF_EDUCATION `l/`
-  * All keywords provided as LEVEL_OF_EDUCATION input must comply with input specifications for add given [**here**](#level_of_education-l).
-
-* ##### YEARS_OF_EXPERIENCE `y/`
-  * All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience-y)..
-
-* ##### TAG `t/`
-  * All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag-t).
-
-* ##### INTERVIEW `i/`
-  * All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview-i).
 
 ### Listing all applicants : `list`
 
@@ -286,99 +183,6 @@ Examples:
 * `find t/friend colleague` finds all applicants with `friend` or `colleague` as values for tag prefix.
 * `find n/John Mary t/friend colleague`
 * `find n/Bob p/87654321 e/bob@gmail.com r/Software Engineering et/Full time s/4000 l/High School y/2 nt/has the credentials d/Not Done`
-
-#### Prefix Input Specifications:
-
-* ##### NAME `n/`
-  * A NAME is considered matching with a ***Name*** only if **at least 1** keyword is equal to **at least 1** word in the ***Name***.
-  * All keywords provided as NAME input must comply with input specifications for add given [**here**](#name-n).
-  * For example:
-    * A `John` input can match with *Name*s such as `John Tan` or `John Lee`. 
-    * A `John Mary` input can match with *Name*s such as `Mary John`, `Mary Lee` or `Long John`.
-
-* ##### PHONE_NUMBER `p/`
-  * A PHONE_NUMBER is considered matching with a ***Contact Number*** only if **at least 1** keyword is equal to **at least 1** word in the ***Contact Number***
-  * All keywords provided as PHONE_NUMBER input must comply with input specifications for add given [**here**](#phone_number-p).
-  * For example:
-    * A `99999999` input can only match with *Contact Number*s that are `99999999`.
-    * A `99999999 88888888` input can only match with *Contact Number*s that are `99999999` and `88888888`.
-
-* ##### EMAIL_ADDRESS `e/`
-  * An EMAIL_ADDRESS is considered matching with an ***Email Address*** only if **at least 1** keyword is equal to **at least 1** word in the ***Email Address***.
-  * All keywords provided as EMAIL_ADDRESS input must comply with input specifications for add given [**here**](#email_address-e).
-  * For example:
-    * A `alexyeoh@example.com` input can match with *Email*s such as `alexyeoh@example.com`.
-    * A `alexyeoh@example.com marysue@gmail.com` input can match with *Email*s such as `alexyeoh@example.com`
-and `marysue@gmail.com`.
-
-* ##### ROLE `r/`
-  * A ROLE is considered matching with a ***Role*** only if **each of every** provided keyword is equal to **at least 1** word in the ***Role***.
-  * All keywords provided as ROLE input must comply with input specifications for add given [**here**](#role-r).
-  * For example:
-    * A `Software` input can match with *Role*s such as `Software Engineer`, `Software` or `Software Developer`
-    * A `Software Engineer` input can match with *Role*s such as `Software Engineer` or `Senior Software Engineer`
-but not with *Role*s such as `Software` or `Software Developer`.
-
-* ##### EMPLOYMENT_TYPE `et/`
-  * An EMPLOYMENT_TYPE is considered matching with an ***Employment Type*** only if it **starts with any** of the keywords in the ***Employment Type***.
-  * All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type-et).
-  * For example:
-    * A `Full time` or `full time` or `full` input will match only with *Employment Type*s that are ```Full time```
-    * A ```Full part``` input will match with all *Employment Type*s that are ```Full time``` or ```Part time```
-    * A ```temp Intern``` input will match with all *Employment Type*s that are ```Temporary``` or ```Internship```
-    * A ```full time bob``` input will throw an exception as ```bob``` is not a term any of the *Employment Type*s start
-    with.
-
-* ##### EXPECTED_SALARY `s/`
-    * An EXPECTED_SALARY is considered matching with a ***Expected Salary*** only if **at least 1** keyword is within a range of `500` from **at least 1** keyword in the ***Expected Salary***.
-    * All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary-s).
-    * For example:
-        * A `3000` input can match with *Expected Salary*s that range from `2500` to `3500` inclusive.
-        * A `2500 5000` input can match with *Expected Salary*s from the ranges `2000` to `3000` inclusive, and `4500` to `5500` inclusive.
-
-* ##### LEVEL_OF_EDUCATION `l/`
-  * LEVEL_OF_EDUCATION can be a fixed number of levels, being `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` and `PhD`.
-  * A LEVEL_OF_EDUCATION is considered matching with a ***level of Education*** only if **at least 1** letter of a keyword is equal to **at least 1** letter in the ***Level of Education***
-  * All keywords provided as LEVEL_OF_EDUCATION input must comply with input specifications for add given [**here**](#level_of_education-l).
-  * For example:
-    * A `H` input can match with ***Level of Education***s such `High School`, but not with *Level of Education*s such as `PhD`
-    * A `High School` input can match with ***Level of Education***s such as `High School`, but not with *Level of Education*s such as `Middle School`
-
-* ##### YEARS_OF_EXPERIENCE `y/`
-    * A YEARS_OF_EXPERIENCE is considered matching with a ***Years Of Experience*** only if the value represented by **at least 1** keyword is larger than or equal to the value represented by the ***Years Of Experience***.
-    * All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience-y).
-    * For example:
-        * A `3` input can match with ***Year Of Experience***s that are higher than or equal to 3.
-        * A `2 3` input can match with ***Year Of Experience***s that are higher than or equal to 2.
-
-* ##### TAG `t/`
-    * Each applicant can have many stored tags, so ***Tags*** will be used to refer to each applicant's stored ***Tag***s.
-    * A TAG is considered matching with a ***Tags*** only if ***at least 1*** keyword is **exactly equals** to **at least 1** ***Tag*** within the ***Tags***..
-    * All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag-t).
-    * For example:
-        * An `old` input can match with applicants that have the ***Tag*** `old`
-        * An `experienced old` input can match with applicants that have the ***Tag*** `experienced`, or `old`, or both.
-
-* ##### INTERVIEW `i/`
-    * An INTERVIEW is considered matching with a ***Interview*** only if the ***Interview***'s time string contains **at least 1** keyword.
-    * All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview-i).
-    * For example:
-        * A `2021` input can match with applicants that have the *Interview* in year 2021.
-        * A `20:21` input can match with applicants that have the *Interview* at time 20:21 on any date.
-        * A `21` input can match with *Interviews* `2021-10-10, 10:00`, `2020-10-21, 10:00`, `2020-10-10, 21:00` or `2020-10-10, 10:21`.
-        
-* ##### NOTES `nt/`
-    * NOTES are considered matching with  ***Notes*** only if  ***Notes*** contains **the entire** keyword.
-    * All keywords provided as NOTES input must comply with input specifications for add given [**here**](#notes-nt).
-    * For example:
-        * A `good in this field` input can match with applicants that have *Notes* containing the `good in this field`.
-        * A `passionate` input can match with applicants that have Notes such as `passionate but inexperienced` and `passionate and experienced`.
-
-* ##### DONE `d/`
-    * An DONE is considered matching with a ***Done*** only if the ***Done***'s status string is either `Done` or `Not Done`.
-    * For example:
-        * A `Done` input can match with applicants that have their *Done* status marked as Done.
-        * A `Not Done` input can match with applicants that have their *Done* status unmarked as Not Done.
         
         
 ### Filtering interviews : `filter_interview`
@@ -526,45 +330,175 @@ If your changes to the data file makes its format invalid, RecruitIn will discar
 
 ## Prefix Input Specifications ***{Advanced}***
 
-### Add Inputs
-
 **Note**: **Alphanumeric** characters refers specifically to characters a-z, A-Z and 0-9.
 
-| Input | Prefix |  Specifications |
-| :---: | :---: | --- |
-| <h4 id="name">NAME</h4> | `n/` | <ul><li>A NAME should only contain alphanumeric characters. Spaces between words are allowed.</li><li>For example:</li><ul><li>NAME inputs such as `John`, `Mary Sue` and `9ine 6ix` are acceptable.</li><li>NAME inputs such as `J@hn`, `Mary S^e` and `B{}b` are not acceptable.</li></ul></ul> |
-| <h4 id="phone_number">PHONE_NUMBER</h4> | `p/` | <ul><li>A PHONE_NUMBER should contain a minimum of 3 digits. No characters other than the digits 0-9 are allowed.</li><li>For example:</li><ul><li>PHONE_NUMBER inputs such as `99999999` and `999` are acceptable.</li><li>PHONE_NUMBER inputs such as `9999 9999` and `88` are not acceptable.</li></ul></ul> |
-| <h4 id="email_address">EMAIL_ADDRESS</h4> | `e/` | <ul><li>An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.</li><li>The **local part**:</li><ul><li>must contain **at least 1** alphanumeric character.</li><li>It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`</li><li>It must **start with** and **end with** an alphanumeric character.</li></ul><li>The **domain part**:</li><ul><li>must contain **at least 2** alphanumeric characters.</li><li>It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`</li></ul><li>For example:</li><ul><li>EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.</li><li>EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.</li></ul></ul> |
-| <h4 id="role">ROLE</h4> | `r/` | <ul><li>A ROLE should only contain **alphanumeric** characters. Spaces between words are allowed.</li><li>For example:</li><ul><li>ROLE inputs such as `Software Engineer` and `Sales Assistant` are acceptable.</li><li>ROLE inputs such as `Softw@re Engin^^r` and `Day + Night Security Guard` are not acceptable.</li></ul></ul> |
-| <h4 id="employment_type">EMPLOYMENT_TYPE</h4> | `et/` | <ul><li>An EMPLOYMENT_TYPE should be one of the following: `Full time`, `Part time`, `Temporary` or `Internship`.</li><li>For example</li><ul><li>EMPLOYMENT_TYPE inputs such as `Full time` and `Internship` are acceptable.</li><li>EMPLOYMENT_TYPE inputs such as `fUlL tiMe` and `iNtErnShIP` are acceptable.</li><li>EMPLOYMENT_TYPE inputs such as `Long term` are not acceptable.</li></ul></ul> |
-| <h4 id="expected_salary">EXPECTED_SALARY</h4> | `s/` | <ul><li>An EXPECTED_SALARY should only represent non-negative integers.</li><ul><li>Non-negative integers range from 0 to 2^(31) - 1 inclusive.</li></ul><li>For example:</li><ul><li>EXPECTED_SALARY inputs such as `0` and `3500` are acceptable.</li><li>EXPECTED_SALARY inputs such as `-600` and `~350` are not acceptable.</li></ul></ul> |
-| <h4 id="level_of_education">LEVEL_OF_EDUCATION</h4> | `l/` | <ul><li>A LEVEL_OF_EDUCATION should be one of the following: `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` or `PhD`. </li><li>A LEVEL_OF_EDUCATION is **case-insensitive**.</li><li>For example:</li><ul><li>LEVEL_OF_EDUCATION inputs such as `Middle School` and `PhD` are acceptable.</li><li>LEVEL_OF_EDUCATION inputs such as `miDDlE scHoOL` and `phD` are acceptable.</li><li>LEVEL_OF_EDUCATION inputs such as `Kindergarten` are not acceptable.</li></ul></ul> |
-| <h4>YEARS_OF_EXPERIENCE</h4> | `y/` | <ul><li>A YEARS_OF_EXPERIENCE should be a **non-negative integer** smaller than or equals to **67** (re-employment age in Singapore).</li><li>For example:</li><ul><li>YEARS_OF_EXPERIENCE inputs such as `0` and `10` are acceptable.</li><li>YEARS_OF_EXPERIENCE inputs such as `-1`, `3.5`, and `100` are not acceptable.</li></ul></ul> |
-| <h4 id="tag">TAG</h4> | `t/` | <ul><li>A TAG should only contain alphanumeric characters. Spaces between words are **not** allowed.</li><li>For example:</li><ul><li>TAG inputs such as `friends` and `colleagues` are allowed.</li><li>TAG inputs such as `best friends`, `old colleagues` and `seni@r` are not allowed.</li></ul></ul> |
-| <h4 id="interview">INTERVIEW</h4> | `i/` | <ul><li>An INTERVIEW should follow the DateTime format `yyyy-MM-dd, H:mm`.</li><li>For example:</li><ul><li>INTERVIEW inputs such as `2021-10-22, 13:00` and `2022-01-30, 3:00` are acceptable.</li><li>INTERVIEW inputs such as `morning`, `2021.10.21` and `2021-10-22 13:00` are not acceptable.</li></ul></ul> |
-| <h4 id="notes">NOTES</h4> | `nt/` | <ul><li>A NOTES can contain any character, number or symbol as there are no restrictions in place.</li><li>For example:</li><ul><li>NOTES inputs such as `This candidate is good!` and `@Applicant123 is suitab13 for th3 job!` are acceptable.</li></ul></ul> |
+### Add Inputs
 
 * Return to [Add](#adding-an-applicant-add).
 * Return to [Edit](#editing-an-applicant--edit).
 
+* ##### NAME `n/`
+    * A NAME should only contain alphanumeric characters. Spaces between words are allowed.
+    * For example:
+        * NAME inputs such as `John`, `Mary Sue` and `9ine 6ix` are acceptable.
+        * NAME inputs such as `J@hn`, `Mary S^e` and `B{}b` are not acceptable.
+* ##### PHONE_NUMBER `p/`
+    * A PHONE_NUMBER should contain a minimum of 3 digits. No characters other than the digits 0-9 are allowed.
+    * For example:
+        * PHONE_NUMBER inputs such as `99999999` and `999` are acceptable.
+        * PHONE_NUMBER inputs such as `9999 9999` and `88` are not acceptable.
+* ##### EMAIL_ADDRESS `e/`
+    * An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.
+    * The **local part**:
+        * must contain **at least 1** alphanumeric character.
+        * It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`
+        * It must **start with** and **end with** an alphanumeric character.
+    * The **domain part**:
+        * must contain **at least 2** alphanumeric characters.
+        * It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with
+          `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`
+    * For example:
+        * EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.
+        * EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.
+* ##### ROLE `r/`
+    * A ROLE should only contain **alphanumeric** characters. Spaces between words are allowed.
+    * For example:
+        * ROLE inputs such as `Software Engineer` and `Sales Assistant` are acceptable.
+        * ROLE inputs such as `Softw@re Engin^^r` and `Day + Night Security Guard` are not acceptable.
+* ##### EMPLOYMENT_TYPE `et/`
+    * An EMPLOYMENT_TYPE should be one of the following: `Full time`, `Part time`, `Temporary` or `Internship`.
+    * An EMPLOYMENT_TYPE is **case-insensitive**.
+    * For example:
+        * EMPLOYMENT_TYPE inputs such as `Full time` and `Internship` are acceptable.
+        * EMPLOYMENT_TYPE inputs such as `fUlL tiMe` and `iNtErnShIP` are acceptable.
+        * EMPLOYMENT_TYPE inputs such as `Long term` are not acceptable.
+* ##### EXPECTED_SALARY `s/`
+    * An EXPECTED_SALARY should only represent non-negative integers.
+        * Non-negative integers range from 0 to 2^(31) - 1 inclusive.
+    * For example:
+        * EXPECTED_SALARY inputs such as `0` and `3500` are acceptable.
+        * EXPECTED_SALARY inputs such as `-600` and `~350` are not acceptable.
+* ##### LEVEL_OF_EDUCATION `l/`
+    * A LEVEL_OF_EDUCATION should be one of the following: `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` or `PhD`.
+    * A LEVEL_OF_EDUCATION is **case-insensitive**.
+    * For example:
+        * LEVEL_OF_EDUCATION inputs such as `Middle School` and `PhD` are acceptable.
+        * LEVEL_OF_EDUCATION inputs such as `miDDlE scHoOL` and `phD` are acceptable.
+        * LEVEL_OF_EDUCATION inputs such as `Kindergarten` are not acceptable.
+* ##### YEARS_OF_EXPERIENCE `y/`
+    * A YEARS_OF_EXPERIENCE should be a **non-negative integer** smaller than or equals to **67** (re-employment age in Singapore).
+    * For example:
+        * YEARS_OF_EXPERIENCE inputs such as `0` and `10` are acceptable.
+        * YEARS_OF_EXPERIENCE inputs such as `-1`, `3.5`, and `100` are not acceptable.
+* ##### TAG `t/`
+    * A TAG should only contain alphanumeric characters. Spaces between words are **not** allowed.
+    * For example:
+        * TAG inputs such as `friends` and `colleagues` are allowed.
+        * TAG inputs such as `best friends`, `old colleagues` and `seni@r` are not allowed.
+* ##### INTERVIEW `i/`
+    * An INTERVIEW should follow the DateTime format `yyyy-MM-dd, H:mm`.
+    * For example:
+        * INTERVIEW inputs such as `2021-10-22, 13:00` and `2022-01-30, 3:00` are acceptable.
+        * INTERVIEW inputs such as `morning`, `2021.10.21` and `2021-10-22 13:00` are not acceptable.
+* ##### NOTES `nt/`
+    * A NOTES can contain any character, number or symbol as there are no restrictions in place.
+    * For example:
+        * NOTES inputs such as `This candidate is good!` and `@Applicant123 is suitab13 for th3 job!` are acceptable.
+
 ### Find Inputs
 
-| Input | Prefix | Specifications |
-| :---: | :---: | --- |
-| NAME | `n/` | <ul><li>A NAME is considered matching with a ***Name*** only if **at least 1** keyword is equal to **at least 1** word in the ***Name***.</li><li>All keywords provided as NAME input must comply with input specifications for add given [**here**](#name)</li><li>For example:</li><ul><li>A `John` input can match with ***Name*** s such as `John Tan` or `John Lee`.</li><li>A `John Mary` input can match with ***Name*** s such as `Mary John`, `Mary Lee` or `Long John`.</li></ul></ul> |
-| PHONE_NUMBER | `p/` | <ul><li>A PHONE_NUMBER is considered matching with a ***Phone Number*** only if **at least 1** keyword is equal to **at least 1** word in the ***Phone Number***</li><li>All keywords provided as PHONE_NUMBER input must comply with input specifications for add given [**here**](#phone_number)</li><li>For example:</li><ul><li>A `99999999` input can only match with ***Phone Number*** s that are `99999999`.</li><li>A `99999999 88888888` input can only match with ***Phone Number*** s that are `99999999` and `88888888`.</li></ul></ul> |
-| EMAIL_ADDRESS | `e/` | <ul><li>An EMAIL_ADDRESS is considered matching with an ***Email Address*** only if **at least 1** keyword is equal to **at least 1** word in the ***Email Address***.</li><li>All keywords provided as EMAIL_ADDRESS input must comply with input specifications for add given [**here**](#email_address)</li><li>For example:</li><ul><li>A `alexyeoh@example.com` input can match with ***Email*** s such as `alexyeoh@example.com`.</li><li>A `alexyeoh@example.com marysue@gmail.com` input can match with ***Email*** s such as `alexyeoh@example.com` and `marysue@gmail.com`.</li></ul></ul> |
-| ROLE | `r/` | <ul><li>A ROLE is considered matching with a ***Role*** only if **each of every** provided keyword is equal to **at least 1** word in the ***Role***.</li><li>All keywords provided as ROLE input must comply with input specifications for add given [**here**](#role)</li><li>For example:</li><ul><li>A `Software` input can match with *Role*s such as `Software Engineer`, `Software` or `Software Developer`.</li><li>A `Software Engineer` input can match with ***Role*** s such as `Software Engineer` or `Senior Software Engineer` but not with ***Role*** s such as `Software` or `Software Developer`.</li></ul></ul> |
-| EMPLOYMENT_TYPE | `et/` | <ul><li>An EMPLOYMENT_TYPE is considered matching with an ***Employment Type*** only if it **starts with any** of the keywords in the ***Employment Type***.</li><li>All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type)</li><li>For example:</li><ul><li>A `Full time` or `full time` or `full` input will match only with ***Employment Type*** s that are `Full time`</li><li>A `Full part` input will match with all ***Employment Type*** s that are `Full time` or `Part time`</li><li>A `temp Intern` input will match with all ***Employment Type*** s that are `Temporary` or `Internship`</li><li>A `full time bob` input will throw an exception as `bob` is not a term any of the ***Employment Type*** s start with.</li></ul></ul> |
-| EXPECTED_SALARY | `s/` | <ul><li>An EXPECTED_SALARY is considered matching with a ***Expected Salary*** only if **at least 1** keyword is within a range of `500` from **at least 1** keyword in the ***Expected Salary***.</li><li>All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary)</li><li>For example:</li><ul><li>A `3000` input can match with ***Expected Salary*** s that range from `2500` to `3500` inclusive.</li><li>A `2500 5000` input can match with ***Expected Salary*** s from the ranges `2000` to `3000` inclusive, and `4500` to `5500` inclusive.</li></ul></ul> |
-|LEVEL_OF_EDUCATION | `l/` | <ul><li>LEVEL_OF_EDUCATION can be a fixed number of levels, being `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` and `PhD`. </li><li>A LEVEL_OF_EDUCATION is considered matching with a ***level of Education*** only if **at least 1** letter of a keyword is equal to **at least 1** letter in the ***Level of Education***.</li><li>All keywords provided as LEVEL_OF_EDUCATION input must comply with input specifications for add given [**here**](#level_of_education)</li><li>For example:</li><ul><li>A `H` input can match with ***Level of Education*** s such `High School`, but not with ***Level of Education*** s such as `PhD`</li><li>A `High School` input can match with ***Level of Education*** s such as `High School`, but not with ***Level of Education*** s such as `Middle School` </li></ul></ul> |
-| YEARS_OF_EXPERIENCE | `y/` | <ul><li>A YEARS_OF_EXPERIENCE is considered matching with a ***Years Of Experience*** only if the value represented by **at least 1** keyword is larger than or equal to the value represented by the ***Years Of Experience***.</li><li>All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience)</li><li>For example:</li><ul><li>A `3` input can match with ***Year Of Experience*** s that are higher than or equal to 3.</li><li>A `2 3` input can match with ***Year Of Experience*** s that are higher than or equal to 2.</li></ul></ul> |
-| TAG | `t/` | <ul><li>Each applicant can have many stored tags, so ***Tags*** will be used to refer to each applicant's stored ***Tag*** s.</li><li>A TAG is considered matching with a ***Tags*** only if ***at least 1*** keyword is **exactly equals** to **at least 1** ***Tag*** within the ***Tags***..</li><li>All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag)</li><li>For example:</li><ul><li>An `old` input can match with applicants that have the ***Tag*** `old`</li><li>An `experienced old` input can match with applicants that have the ***Tag*** `experienced`, or `old`, or both.</li></ul><ul> |
-| INTERVIEW | `i/` | <ul><li>An INTERVIEW is considered matching with a ***Interview*** only if the ***Interview***'s time string contains **at least 1** keyword.</li><li>All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview)</li><li>For example:</li><ul><li>A `2021` input can match with applicants that have the ***Interview*** in year 2021.</li><li>A `20:21` input can match with applicants that have the ***Interview*** at time 20:21 on any date.</li><li>A `21` input can match with ***Interviews*** `2021-10-10, 10:00`, `2020-10-21, 10:00`, `2020-10-10, 21:00` or `2020-10-10, 10:21`.</li></ul><ul> |
-| NOTES | `nt/` | <ul><li>NOTES are considered matching with  ***Notes*** only if  ***Notes*** contains **the entire** keyword.</li><li>All keywords provided as NOTES input must comply with input specifications for add given [**here**](#notes)</li><li>For example:</li><ul><li>A `good in this field` input can match with applicants that have ***Notes*** containing the `good in this field`.</li><li>A `passionate` input can match with applicants that have Notes such as `passionate but inexperienced` and `passionate and experienced`.</li></ul></ul> |
-| DONE | `d/` | <ul><li>An DONE is considered matching with a ***Done*** only if the ***Done***'s status string is either `Done` or `Not Done`.</li><li>For example:</li><ul><li>A `Done` input can match with applicants that have their ***Done*** status marked as Done.</li><li>A `Not Done` input can match with applicants that have their *Done* status unmarked as Not Done.</li></ul></ul> |
-
 * Return to [Find](#finding-an-applicant--find)
+
+* ##### NAME `n/`
+    * A NAME is considered matching with a ***Name*** only if **at least 1** keyword is equal to **at least 1** word in the ***Name***.
+    * All keywords provided as NAME input must comply with input specifications for add given [**here**](#name-n).
+    * For example:
+        * A `John` input can match with ***Name*** s such as `John Tan` or `John Lee`.
+        * A `John Mary` input can match with ***Name*** s such as `Mary John`, `Mary Lee` or `Long John`.
+
+* ##### PHONE_NUMBER `p/`
+    * A PHONE_NUMBER is considered matching with a ***Contact Number*** only if **at least 1** keyword is equal to **at least 1** word in the ***Contact Number***
+    * All keywords provided as PHONE_NUMBER input must comply with input specifications for add given [**here**](#phone_number-p).
+    * For example:
+        * A `99999999` input can only match with ***Contact Number*** s that are `99999999`.
+        * A `99999999 88888888` input can only match with ***Contact Number*** s that are `99999999` and `88888888`.
+
+* ##### EMAIL_ADDRESS `e/`
+    * An EMAIL_ADDRESS is considered matching with an ***Email Address*** only if **at least 1** keyword is equal to **at least 1** word in the ***Email Address***.
+    * All keywords provided as EMAIL_ADDRESS input must comply with input specifications for add given [**here**](#email_address-e).
+    * For example:
+        * A `alexyeoh@example.com` input can match with ***Email*** s such as `alexyeoh@example.com`.
+        * A `alexyeoh@example.com marysue@gmail.com` input can match with ***Email*** s such as `alexyeoh@example.com`
+          and `marysue@gmail.com`.
+
+* ##### ROLE `r/`
+    * A ROLE is considered matching with a ***Role*** only if **each of every** provided keyword is equal to **at least 1** word in the ***Role***.
+    * All keywords provided as ROLE input must comply with input specifications for add given [**here**](#role-r).
+    * For example:
+        * A `Software` input can match with ***Role*** s such as `Software Engineer`, `Software` or `Software Developer`
+        * A `Software Engineer` input can match with ***Role*** s such as `Software Engineer` or `Senior Software Engineer`
+          but not with ***Role*** s such as `Software` or `Software Developer`.
+
+* ##### EMPLOYMENT_TYPE `et/`
+    * An EMPLOYMENT_TYPE is considered matching with an ***Employment Type*** only if it **starts with any** of the keywords in the ***Employment Type***.
+    * All keywords provided as EMPLOYMENT_TYPE input must comply with input specifications for add given [**here**](#employment_type-et).
+    * For example:
+        * A `Full time` or `full time` or `full` input will match only with ***Employment Type*** s that are ```Full time```
+        * A ```Full part``` input will match with all ***Employment Type*** s that are ```Full time``` or ```Part time```
+        * A ```temp Intern``` input will match with all ***Employment Type*** s that are ```Temporary``` or ```Internship```
+        * A ```full time bob``` input will throw an exception as ```bob``` is not a term any of the ***Employment Type*** s start
+          with.
+
+* ##### EXPECTED_SALARY `s/`
+    * An EXPECTED_SALARY is considered matching with a ***Expected Salary*** only if **at least 1** keyword is within a range of `500` from **at least 1** keyword in the ***Expected Salary***.
+    * All keywords provided as EXPECTED_SALARY input must comply with input specifications for add given [**here**](#expected_salary-s).
+    * For example:
+        * A `3000` input can match with ***Expected Salary*** s that range from `2500` to `3500` inclusive.
+        * A `2500 5000` input can match with ***Expected Salary*** s from the ranges `2000` to `3000` inclusive, and `4500` to `5500` inclusive.
+
+* ##### LEVEL_OF_EDUCATION `l/`
+    * LEVEL_OF_EDUCATION can be a fixed number of levels, being `Elementary`, `Middle School`, `High School`, `University`, `Bachelors`, `Masters` and `PhD`.
+    * A LEVEL_OF_EDUCATION is considered matching with a ***level of Education*** only if **at least 1** letter of a keyword is equal to **at least 1** letter in the ***Level of Education***
+    * All keywords provided as LEVEL_OF_EDUCATION input must comply with input specifications for add given [**here**](#level_of_education-l).
+    * For example:
+        * A `H` input can match with ***Level of Education*** s such `High School`, but not with *Level of Education*s such as `PhD`
+        * A `High School` input can match with ***Level of Education*** s such as `High School`, but not with *Level of Education*s such as `Middle School`
+
+* ##### YEARS_OF_EXPERIENCE `y/`
+    * A YEARS_OF_EXPERIENCE is considered matching with a ***Years Of Experience*** only if the value represented by **at least 1** keyword is larger than or equal to the value represented by the ***Years Of Experience***.
+    * All keywords provided as YEARS_OF_EXPERIENCE input must comply with input specifications for add given [**here**](#years_of_experience-y).
+    * For example:
+        * A `3` input can match with ***Year Of Experience*** s that are higher than or equal to 3.
+        * A `2 3` input can match with ***Year Of Experience*** s that are higher than or equal to 2.
+
+* ##### TAG `t/`
+    * Each applicant can have many stored tags, so ***Tags*** will be used to refer to each applicant's stored ***Tag*** s.
+    * A TAG is considered matching with a ***Tags*** only if ***at least 1*** keyword is **exactly equals** to **at least 1** ***Tag*** within the ***Tags***..
+    * All keywords provided as TAG input must comply with input specifications for add given [**here**](#tag-t).
+    * For example:
+        * An `old` input can match with applicants that have the ***Tag*** `old`
+        * An `experienced old` input can match with applicants that have the ***Tag*** `experienced`, or `old`, or both.
+
+* ##### INTERVIEW `i/`
+    * An INTERVIEW is considered matching with a ***Interview*** only if the ***Interview***'s time string contains **at least 1** keyword.
+    * All keywords provided as INTERVIEW input must comply with input specifications for add given [**here**](#interview-i).
+    * For example:
+        * A `2021` input can match with applicants that have the ***Interview*** in year 2021.
+        * A `20:21` input can match with applicants that have the ***Interview*** at time 20:21 on any date.
+        * A `21` input can match with ***Interviews*** `2021-10-10, 10:00`, `2020-10-21, 10:00`, `2020-10-10, 21:00` or `2020-10-10, 10:21`.
+
+* ##### NOTES `nt/`
+    * NOTES are considered matching with  ***Notes*** only if  ***Notes*** contains **the entire** keyword.
+    * All keywords provided as NOTES input must comply with input specifications for add given [**here**](#notes-nt).
+    * For example:
+        * A `good in this field` input can match with applicants that have ***Notes*** containing the `good in this field`.
+        * A `passionate` input can match with applicants that have Notes such as `passionate but inexperienced` and `passionate and experienced`.
+
+* ##### DONE `d/`
+    * An DONE is considered matching with a ***Done*** only if the ***Done***'s status string is either `Done` or `Not Done`.
+    * For example:
+        * A `Done` input can match with applicants that have their ***Done*** status marked as Done.
+        * A `Not Done` input can match with applicants that have their ***Done*** status unmarked as Not Done.
 
 --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Addresses #292, #281, #286 and #285
- Tag input is explained in detail under add and edit. (#285)
- Added Edit Command anchor link to table of contents. (#292) (#281)
- Added specifications under Edit Command description to indicate that prefix inputs for Edit is taken as a single value. Users should understand that `s/4000 5000` means an input of `4000 5000`, which does not adhere to the Add Input Specifications. (#286)
- Delete, Mark and Unmark inputs are specified to be unique.
- Shifted Prefix Inputs to its own sections with links returning to the command itself. Anchor links updated and tested.
- Added Markdown Styling to highlight certain "Do Nots" that would lead to an error.