### PR TITLE
Change email regex to be more strict to ensure most emails are safe and valid

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -151,12 +151,14 @@ Examples:
   * An EMAIL_ADDRESS should contain a **local part** and a **domain part**, separated by an `@` character.
   * The **local part**:
     * must contain **at least 1** alphanumeric character. 
-    * It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. e.g. `John-a-bc`
+    * It can contain alphanumeric characters separated by any 1 of these characters `+_.-`. (i.e. `John-a-bc`)
     * It must **start with** and **end with** an alphanumeric character.
   * The **domain part**:
-    * must contain **at least 2** alphanumeric characters.
-    * It can contain sections, each containing alphanumeric characters separated by `_`. Each section must end with
-    `.`. The sections must be followed by **at least** 2 alphanumeric characters. e.g. `John-a.a-b-c.bc`
+    * must contain **at least 2** domain labels. Each domain label, **except the final domain label**, must start with an 
+alphanumeric character and end with a `.`. 
+    * The final domain label must have **at least 2** alphanumeric characters, but does not need to end with
+a `.` unlike its preceding domain labels. (i.e. `John@u.sg` is valid)
+    * The domain label can contain alphanumeric characters separated by `-`. (i.e. `John@u-u.sg`)
   * For example:
     * EMAIL_ADDRESS inputs such as `PeterJack_1190@example.com` and `e1234567@u.nus.edu` are acceptable.
     * EMAIL_ADDRESS inputs such as `peterjack@example.c` and `peter..jack@example.com` are unacceptable.

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -18,6 +18,7 @@ public class Email {
             + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
+            + "    - consist of at least 2 domain labels\n"
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
@@ -28,7 +29,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -51,15 +51,15 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("a@bc")); // minimal, no TLD (Top Level Domain)
+        assertFalse(Email.isValidEmail("test@localhost")); // alphabets only, no TLD
+        assertFalse(Email.isValidEmail("123@145")); // numeric local part and domain name, no TLD
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part


### PR DESCRIPTION
Addresses #269 

- Previously, emails without TLDs (Top Level Domains), such as `admin@mailserver1` are allowed. This is considered by [ICANN](https://www.icann.org/en/announcements/details/new-gtld-dotless-domain-names-prohibited-30-8-2013-en) to be an unsafe email format. Hence, I decided to disallow such an email format.
- The RFC5322 standard for email validation allows characters such as ```|_!#$%&'*+/=?`{|}~^.```. Of these allowed characters, `|` and `'` are known to be used in emails by attackers in SQL Injection attacks. Other characters may cause lead to issues when used with database operations. As such, I have decided to keep AB3's strict restrictions of only alphanumeric characters (excluding `_`) to only accept professional and safe email addresses.
- `EmailTest` class has been updated to test for new changes to the acceptable email format.
- UG has been updated to reflect the changes.