### PR TITLE
Modify `isSamePerson`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -107,12 +107,17 @@ Scroll down to the bottom and click on `recruitIn.jar`.
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
-  
-* Sections with headings appended with ***{Advanced}*** are intended for the advanced user.
 
-* Duplicate applicants are not allowed. For two applicants to be duplicate, 
-they must have the same ***Contact Number*** and ***Email***. An error message will show if you attempt to
-`add` or `edit` applicants in a manner that will lead to duplicate stored applicants.
+</div>
+
+
+<div markdown="block" class="alert alert-primary">
+
+**:information_source: Notes about the applicants:**<br>
+
+* Duplicate applicants are not allowed. <br>
+  For two applicants to be duplicate, they must have either the same ***Phone Number*** or ***Email*** or both. 
+  An error message will show if you attempt to `add` or `edit` applicants in a manner that will lead to duplicate stored applicants.
 
 </div>
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -13,6 +13,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -53,7 +55,6 @@ public class AddCommand extends Command {
 
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
 
     private final Person toAdd;
 
@@ -70,11 +71,35 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            List<Person> duplicates = model.getDuplicate(toAdd);
+            assert !duplicates.isEmpty() : "There should be at least 1 duplicate.";
+
+            throw new CommandException(createDuplicateMessage(duplicates, toAdd));
         }
 
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    /**
+     * Creates a UI message informing user of existing duplicate applicants.
+     * {@code duplicates} provided must contain at least 1 applicant.
+     *
+     * @param duplicates List of applicants who share the same phone number and email with {@code editedPerson}
+     * @param toCheck applicant to be checked for duplicates with
+     * @return String accumulation of all duplicate applicants
+     */
+    private String createDuplicateMessage(List<Person> duplicates, Person toCheck) {
+        assert toCheck != null;
+        assert duplicates != null;
+        assert !duplicates.isEmpty() : "There should be at least 1 duplicate";
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Person duplicate : duplicates) {
+            stringBuilder.append(duplicate);
+        }
+        return "The applicant to be added " + toCheck
+                + " shares either the same phone number or email as the following applicant(s):\n"
+                + stringBuilder;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -67,6 +67,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns first occurrence of a person (if any) with same identity as {@code person} in the address book.
+     */
+    public List<Person> getDuplicate(Person person) {
+        requireNonNull(person);
+        return persons.getDuplicate(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -56,6 +57,11 @@ public interface Model {
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);
+
+    /**
+     * Returns first occurrence of a person (if any) with same identity as {@code person} in the address book.
+     */
+    List<Person> getDuplicate(Person person);
 
     /**
      * Deletes the given person.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -92,6 +94,12 @@ public class ModelManager implements Model {
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return addressBook.hasPerson(person);
+    }
+
+    @Override
+    public List<Person> getDuplicate(Person person) {
+        requireNonNull(person);
+        return addressBook.getDuplicate(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -153,7 +153,7 @@ public class Person {
 
         return otherPerson != null
                 && (otherPerson.getEmail().equals(getEmail())
-                        && otherPerson.getPhone().equals(getPhone()));
+                        || otherPerson.getPhone().equals(getPhone()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -143,7 +143,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same email and contact number.
+     * Returns true if both persons have the same email or contact number.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -34,6 +35,14 @@ public class UniquePersonList implements Iterable<Person> {
     public boolean contains(Person toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSamePerson);
+    }
+
+    /**
+     * Returns first occurrence of a person (if any) with same identity as {@code person} in the address book.
+     */
+    public List<Person> getDuplicate(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().filter(x -> x.isSamePerson(toCheck)).collect(Collectors.toList());
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -15,7 +15,19 @@
   }, {
     "name": "Janice Paula",
     "phone": "94351253",
-    "email": "alice@example.com",
+    "email": "Janice@example.com",
+    "role": "Preschool Teacher",
+    "employmentType": "Part time",
+    "expectedSalary": "7500",
+    "levelOfEducation": "PhD",
+    "experience": "1",
+    "interview": "-",
+    "notes": "-",
+    "done": "Not Done"
+  }, {
+    "name": "Annie Paul",
+    "phone": "99009900",
+    "email": "Janice@example.com",
     "role": "Preschool Teacher",
     "employmentType": "Part time",
     "expectedSalary": "7500",

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.generateDuplicateErrorMessage;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,8 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(new AddCommand(personInList), model,
+                generateDuplicateErrorMessage("The applicant to be added ", personInList, personInList));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.generateDuplicateErrorMessage;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -48,7 +49,9 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class,
+                generateDuplicateErrorMessage("The applicant to be added ", validPerson, validPerson), () ->
+                        addCommand.execute(modelStub));
     }
 
     @Test
@@ -131,7 +134,9 @@ public class AddCommandTest {
 
         @Override
         public List<Person> getDuplicate(Person person) {
-            throw new AssertionError("This method should not be called.");
+            ArrayList<Person> result = new ArrayList<>();
+            result.add(person);
+            return result;
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -125,6 +126,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public List<Person> getDuplicate(Person person) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -186,4 +186,18 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Generates a duplicate applicant error message using {@code duplicates} as existing duplicate applicants
+     * and {@code toCheck} as the applicant to be checked for duplicates.
+     */
+    public static String generateDuplicateErrorMessage(String message, Person toCheck, Person ... duplicates) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Person duplicate : duplicates) {
+            stringBuilder.append(duplicate);
+        }
+        return message + toCheck
+                + " shares either the same phone number or email as the following applicant(s):\n"
+                + stringBuilder;
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.generateDuplicateErrorMessage;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -104,7 +105,8 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model,
+                generateDuplicateErrorMessage("Your edited applicant ", firstPerson, firstPerson));
     }
 
     @Test
@@ -116,7 +118,8 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model,
+                generateDuplicateErrorMessage("Your edited applicant ", personInList, personInList));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -103,6 +103,34 @@ public class AddressBookTest {
     }
 
     @Test
+    public void getDuplicate_noPersonInAddressBook_returnsEmptyList() {
+        assertTrue(addressBook.getDuplicate(AMY).isEmpty());
+    }
+
+    @Test
+    public void getDuplicate_noPersonWithSameIdentityFieldsInAddressBook_returnsEmptyList() {
+        addressBook.addPerson(AMY);
+        assertTrue(addressBook.getDuplicate(BOB).isEmpty());
+    }
+
+    @Test
+    public void getDuplicate_personWithSameIdentityFieldsInAddressBook_returnsDuplicatePerson() {
+        addressBook.addPerson(AMY);
+        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).withTags(VALID_TAG_HUSBAND).build();
+        assertEquals(addressBook.getDuplicate(editedBob).get(0), AMY);
+    }
+
+    @Test
+    public void getDuplicate_personsWithSameIdentityFieldsInAddressBook_returnsDuplicatePersons() {
+        addressBook.addPerson(AMY);
+        addressBook.addPerson(BOB);
+        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).withTags(VALID_TAG_HUSBAND).build();
+        List<Person> duplicates = addressBook.getDuplicate(editedBob);
+        assertEquals(duplicates.get(0), AMY);
+        assertEquals(duplicates.get(1), BOB);
+    }
+
+    @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -47,10 +47,31 @@ public class AddressBookTest {
     }
 
     @Test
-    public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
-        // Two persons with the same email and contact number
-        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+    public void resetData_withDuplicatePersonsSameContactNumberDifferentEmail_throwsDuplicatePersonException() {
+        // Two persons with the same contact number but different email
+        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY)
                 .withTags(VALID_TAG_HUSBAND).build();
+        List<Person> newPersons = Arrays.asList(AMY, editedBob);
+        AddressBookStub newData = new AddressBookStub(newPersons);
+
+        assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void resetData_withDuplicatePersonsSameEmailDifferentContactNumber_throwsDuplicatePersonException() {
+        // Two persons with the same email but different contact number
+        Person editedBob = new PersonBuilder(BOB).withEmail(VALID_EMAIL_AMY).withTags(VALID_TAG_HUSBAND).build();
+        List<Person> newPersons = Arrays.asList(AMY, editedBob);
+        AddressBookStub newData = new AddressBookStub(newPersons);
+
+        assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void resetData_withDuplicatePersonsSameEmailSameContactNumber_throwsDuplicatePersonException() {
+        // Two persons with the same email but different contact number
+        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY).withTags(VALID_TAG_HUSBAND).build();
         List<Person> newPersons = Arrays.asList(AMY, editedBob);
         AddressBookStub newData = new AddressBookStub(newPersons);
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,20 +3,26 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class ModelManagerTest {
 
@@ -86,6 +92,33 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void getDuplicate_noPersonInAddressBook_returnsEmptyList() {
+        assertTrue(modelManager.getDuplicate(ALICE).isEmpty());
+    }
+
+    @Test
+    public void getDuplicate_noDuplicatePersonInAddressBook_returnsEmptyList() {
+        modelManager.addPerson(ALICE);
+        assertTrue(modelManager.getDuplicate(BOB).isEmpty());
+    }
+
+    @Test
+    public void getDuplicate_duplicatePersonInAddressBook_returnsDuplicatePersonInAddressBook() {
+        modelManager.addPerson(ALICE);
+        assertEquals(modelManager.getDuplicate(ALICE).get(0), ALICE);
+    }
+
+    @Test
+    public void getDuplicate_duplicatePersonsInAddressBook_returnsDuplicatePersonsInAddressBook() {
+        Person bobWithAmyPhone = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).build();
+        modelManager.addPerson(AMY);
+        modelManager.addPerson(BOB);
+        List<Person> duplicates = modelManager.getDuplicate(bobWithAmyPhone);
+        assertEquals(duplicates.get(0), AMY);
+        assertEquals(duplicates.get(1), BOB);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -40,20 +40,21 @@ public class PersonTest {
         Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).build();
         assertTrue(AMY.isSamePerson(editedBob));
 
+        // same email but different contact number, all other attributes same -> returns true
+        editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
+        // different email but same contact number, all other attributes same -> returns true
+        editedBob = new PersonBuilder(BOB).withEmail(VALID_EMAIL_AMY).build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
         // different email and contact number, all other attributes same -> returns false
         editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).build();
         assertFalse(BOB.isSamePerson(editedBob));
 
-        // same email but different contact number, all other attributes same -> returns false
-        editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).build();
-        assertFalse(BOB.isSamePerson(editedBob));
-
-        // different email but same contact number, all other attributes same -> returns false
-        editedBob = new PersonBuilder(BOB).withEmail(VALID_EMAIL_AMY).build();
-        assertFalse(BOB.isSamePerson(editedBob));
-
-        // email differs in case, all other attributes same -> returns false
-        editedBob = new PersonBuilder(BOB).withEmail(VALID_EMAIL_BOB.toUpperCase()).build();
+        // checks case sensitiveness of email
+        // email same but differing in case, different phone number, all other attributes same -> returns false
+        editedBob = new PersonBuilder(BOB).withEmail(VALID_EMAIL_BOB.toUpperCase()).withPhone(VALID_PHONE_AMY).build();
         assertFalse(BOB.isSamePerson(editedBob));
     }
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -51,6 +51,36 @@ public class UniquePersonListTest {
     }
 
     @Test
+    public void getDuplicate_noPersonsInList_returnsEmptyList() {
+        assertTrue(uniquePersonList.getDuplicate(AMY).isEmpty());
+    }
+
+    @Test
+    public void getDuplicate_noPersonWithSameIdentityFieldsInList_returnsEmptyList() {
+        uniquePersonList.add(AMY);
+        assertTrue(uniquePersonList.getDuplicate(BOB).isEmpty());
+    }
+
+    @Test
+    public void getDuplicate_personWithSameIdentityFieldsInList_returnsDuplicatePerson() {
+        uniquePersonList.add(AMY);
+        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY)
+                .withTags(VALID_TAG_HUSBAND).build();
+        assertEquals(uniquePersonList.getDuplicate(editedBob).get(0), AMY);
+    }
+
+    @Test
+    public void getDuplicate_personsWithSameIdentityFieldsInLIst_returnsDuplicatePersons() {
+        uniquePersonList.add(AMY);
+        uniquePersonList.add(BOB);
+        Person editedBob = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY)
+                .withTags(VALID_TAG_HUSBAND).build();
+        List<Person> duplicates = uniquePersonList.getDuplicate(editedBob);
+        assertEquals(duplicates.get(0), AMY);
+        assertEquals(duplicates.get(1), BOB);
+    }
+
+    @Test
     public void add_nullPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniquePersonList.add(null));
     }
@@ -170,4 +200,5 @@ public class UniquePersonListTest {
         assertThrows(UnsupportedOperationException.class, ()
             -> uniquePersonList.asUnmodifiableObservableList().remove(0));
     }
+
 }


### PR DESCRIPTION
Addresses #253 
- Changed `isSamePerson` method of `Person` class to recognize two applicants as duplicates if they share either the same phone number or email or both.
- Added `getDuplicate` method to `AddressBook`, `ModelManager`, `UniquePersonList` to find applicants in the AddressBook who are considered duplicate to a specific applicant.
- `getDuplicate` method used in `EditCommand`. `EditCommand` is now changed to **only** allow changes that would lead to a duplicate applicant if the duplicate applicant is the applicant being edited. It will **disallow** changes that would lead to a duplicate of applicant(s) who are not being edited.
- `getDuplicate` is used in `AddCommand` and `EditCommand` to generate more **informative** error messages. It will tell the user exactly which existing applicants are duplicates of what he/she is trying to add/edit.
- Unit Testing have been updated to test the above changes. In particular, a method is added to mimic the duplicate applicant error message.
- Added a separate markdown block to specifically explain that duplicate applicants are not allowed. Could be useful in the future to explain what each part of a displayed applicant means.