### PR TITLE
Fix mark and unmark PED bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -342,6 +342,7 @@ Marks the specified applicant by index from the list in RecruitIn as "Done" (hav
 Format: `mark INDEX…​`
 
 * Marks the applicant at the specified `INDEX` as "Done".
+* An applicant that is has status "Done" cannot be marked again.
 * The `INDEX` refers to the index number shown in the displayed applicants list.
 * At least one `INDEX` must be given. (i.e. `mark ` is not a valid command)
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
@@ -361,6 +362,7 @@ Unmarks the specified applicant by index from the list in RecruitIn to "Not Done
 Format: `unmark INDEX…​`
 
 * Unmarks the applicant at the specified `INDEX` to "Not Done".
+* An applicant that is has status "Not Done" cannot be unmarked again.
 * The `INDEX` refers to the index number shown in the displayed applicants list.
 * At least one `INDEX` must be given. (i.e. `unmark ` is not a valid command)
 * `INDEX` **must be a positive integer** 1, 2, 3, …​

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -24,6 +24,8 @@ public class MarkCommand extends MarkingCommand {
             + "Example: " + COMMAND_WORD + " 1 4 7";
 
     public static final String MESSAGE_MARKED_PERSON_SUCCESS = "Marked Person(s) as Done: \n%1$s";
+    public static final String MESSAGE_MARKING_MARKED_PERSON =
+            "A person that is already marked as Done cannot be marked again";
 
     private final Index[] targetIndexes;
 
@@ -37,6 +39,15 @@ public class MarkCommand extends MarkingCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         StringBuilder result = new StringBuilder();
+
+        boolean markingMarkedPerson;
+        for (Index checkIndex : targetIndexes) {
+            Person personToCheck = lastShownList.get(checkIndex.getZeroBased());
+            markingMarkedPerson = model.checkForMarkedPerson(personToCheck);
+            if (markingMarkedPerson) {
+                throw new CommandException(MESSAGE_MARKING_MARKED_PERSON);
+            }
+        }
 
         for (Index targetIndex : targetIndexes) {
             if (targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -42,6 +42,9 @@ public class MarkCommand extends MarkingCommand {
 
         boolean markingMarkedPerson;
         for (Index checkIndex : targetIndexes) {
+            if (checkIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
             Person personToCheck = lastShownList.get(checkIndex.getZeroBased());
             markingMarkedPerson = model.checkForMarkedPerson(personToCheck);
             if (markingMarkedPerson) {
@@ -50,9 +53,6 @@ public class MarkCommand extends MarkingCommand {
         }
 
         for (Index targetIndex : targetIndexes) {
-            if (targetIndex.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
             Person personToMark = lastShownList.get(targetIndex.getZeroBased());
             model.markPerson(personToMark);
             result.append(personToMark);

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -42,6 +42,9 @@ public class UnmarkCommand extends MarkingCommand {
 
         boolean unmarkingUnmarkedPerson;
         for (Index checkIndex : targetIndexes) {
+            if (checkIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
             Person personToCheck = lastShownList.get(checkIndex.getZeroBased());
             unmarkingUnmarkedPerson = model.checkForMarkedPerson(personToCheck);
             if (unmarkingUnmarkedPerson) {
@@ -50,9 +53,6 @@ public class UnmarkCommand extends MarkingCommand {
         }
 
         for (Index targetIndex : targetIndexes) {
-            if (targetIndex.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-            }
             Person personToUnmark = lastShownList.get(targetIndex.getZeroBased());
             model.unmarkPerson(personToUnmark);
             result.append(personToUnmark);

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -46,7 +46,7 @@ public class UnmarkCommand extends MarkingCommand {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
             Person personToCheck = lastShownList.get(checkIndex.getZeroBased());
-            unmarkingUnmarkedPerson = model.checkForMarkedPerson(personToCheck);
+            unmarkingUnmarkedPerson = model.checkForUnmarkedPerson(personToCheck);
             if (unmarkingUnmarkedPerson) {
                 throw new CommandException(MESSAGE_UNMARKING_UNMARKED_PERSON);
             }

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -24,6 +24,8 @@ public class UnmarkCommand extends MarkingCommand {
             + "Example: " + COMMAND_WORD + " 1 4 7";
 
     public static final String MESSAGE_UNMARKED_PERSON_SUCCESS = "Unmarked Person(s) to Not Done: \n%1$s";
+    public static final String MESSAGE_UNMARKING_UNMARKED_PERSON =
+            "A person that is already unmarked as Not Done cannot be unmarked again";
 
     private final Index[] targetIndexes;
 
@@ -37,6 +39,15 @@ public class UnmarkCommand extends MarkingCommand {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         StringBuilder result = new StringBuilder();
+
+        boolean unmarkingUnmarkedPerson;
+        for (Index checkIndex : targetIndexes) {
+            Person personToCheck = lastShownList.get(checkIndex.getZeroBased());
+            unmarkingUnmarkedPerson = model.checkForMarkedPerson(personToCheck);
+            if (unmarkingUnmarkedPerson) {
+                throw new CommandException(MESSAGE_UNMARKING_UNMARKED_PERSON);
+            }
+        }
 
         for (Index targetIndex : targetIndexes) {
             if (targetIndex.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -105,6 +105,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.markPerson(toMark);
     }
 
+    public boolean checkForMarkedPerson(Person toCheck) {
+        return persons.checkForMarkedPerson(toCheck);
+    }
+
     public void unmarkPerson(Person toUnmark) {
         persons.unmarkPerson(toUnmark);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -113,6 +113,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.unmarkPerson(toUnmark);
     }
 
+    public boolean checkForUnmarkedPerson(Person toCheck) {
+        return persons.checkForUnmarkedPerson(toCheck);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -98,6 +98,12 @@ public interface Model {
     void markPerson(Person target);
 
     /**
+     * Checks if the given person has already been marked "Done".
+     * The person must exist in the address book.
+     */
+    boolean checkForMarkedPerson(Person target);
+
+    /**
      * Unmarks the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -108,4 +108,10 @@ public interface Model {
      * The person must exist in the address book.
      */
     void unmarkPerson(Person target);
+
+    /**
+     * Checks if the given person has already been unmarked "Not Done".
+     * The person must exist in the address book.
+     */
+    boolean checkForUnmarkedPerson(Person target);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -174,4 +174,10 @@ public class ModelManager implements Model {
         addressBook.unmarkPerson(target);
     }
 
+    @Override
+    public boolean checkForUnmarkedPerson(Person target) {
+        requireAllNonNull(target);
+        return addressBook.checkForUnmarkedPerson(target);
+    }
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -163,6 +163,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean checkForMarkedPerson(Person target) {
+        requireAllNonNull(target);
+        return addressBook.checkForMarkedPerson(target);
+    }
+
+    @Override
     public void unmarkPerson(Person target) {
         requireAllNonNull(target);
         addressBook.unmarkPerson(target);

--- a/src/main/java/seedu/address/model/done/Done.java
+++ b/src/main/java/seedu/address/model/done/Done.java
@@ -10,6 +10,8 @@ public class Done {
 
     public static final String STATUS_DONE = "Done";
     public static final String STATUS_UNDONE = "Not Done";
+    public static final Done DONE = new Done(STATUS_DONE);
+    public static final Done UNDONE = new Done(STATUS_UNDONE);
 
     public static final String FIND_MESSAGE_CONSTRAINTS = "You can only search for Done or Not Done";
     private String doneStatus;

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.done.Done;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
@@ -120,6 +121,23 @@ public class UniquePersonList implements Iterable<Person> {
         Person markedPerson = internalList.get(index);
         markedPerson.getDone().setAsDone();
         internalList.set(index, markedPerson);
+
+    }
+
+    /**
+     * Checks the status of the person in the list.
+     * If the status of the person is "Done" returns true; false otherwise.
+     */
+    public boolean checkForMarkedPerson(Person toCheck) {
+        requireNonNull(toCheck);
+
+        int index = internalList.indexOf(toCheck);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+
+        Person markedPerson = internalList.get(index);
+        return markedPerson.getDone().equals(Done.DONE);
 
     }
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -159,6 +159,23 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Checks the status of the person in the list.
+     * If the status of the person is "Not Done" returns true; false otherwise.
+     */
+    public boolean checkForUnmarkedPerson(Person toCheck) {
+        requireNonNull(toCheck);
+
+        int index = internalList.indexOf(toCheck);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+
+        Person markedPerson = internalList.get(index);
+        return markedPerson.getDone().equals(Done.UNDONE);
+
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -155,6 +155,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean checkForMarkedPerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean checkForUnmarkedPerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void unmarkPerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
### Changes
Fixes #272 
Fixes #273 
Fixes #274 
1) Disallow a "Done" applicant to be marked again.
2) Disallow a "Not Done" applicant to be unmarked again.