### PR TITLE
Reduce method length and remove deep nesting

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -96,6 +96,27 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
+        // An existing person that is not the person being edited is a disallowed duplicate if it is a duplicate of
+        // the person being edited.
+        checkDisallowedDuplicates(model, personToEdit, editedPerson);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+    }
+
+    /**
+     * Checks if {@code editedPerson} is a duplicate of any existing Persons in {@code model} other than the
+     * {@code personToEdit} and throws an exception if true.
+     *
+     * @param model Model object to be checked for duplicate Persons
+     * @param personToEdit Person being edited
+     * @param editedPerson Person with edits made
+     * @throws CommandException if {@code editedPerson} is a duplicate of any existing Persons in {@code model}
+     * other than the {@code personToEdit}
+     */
+    private void checkDisallowedDuplicates(Model model, Person personToEdit, Person editedPerson)
+            throws CommandException {
         // check if editing this person will lead to duplicates in the addressbook
         if (model.hasPerson(editedPerson)) {
             List<Person> duplicates = model.getDuplicate(editedPerson);
@@ -112,10 +133,6 @@ public class EditCommand extends Command {
                 throw new CommandException(createDuplicateMessage(disallowedDuplicates, editedPerson));
             }
         }
-
-        model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -53,57 +53,109 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
+        parseNameIfAny(argMultimap, editPersonDescriptor);
 
-        if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
-            editPersonDescriptor.setRole(ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get()));
-        }
+        parsePhoneIfAny(argMultimap, editPersonDescriptor);
 
-        if (argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).isPresent()) {
-            editPersonDescriptor.setEmploymentType(
-                    ParserUtil.parseEmploymentType(argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).get()));
-        }
+        parseEmailIfAny(argMultimap, editPersonDescriptor);
 
-        if (argMultimap.getValue(PREFIX_EXPECTED_SALARY).isPresent()) {
-            editPersonDescriptor.setExpectedSalary(ParserUtil.parseExpectedSalary(argMultimap
-                    .getValue(PREFIX_EXPECTED_SALARY).get()));
-        }
+        parseRoleIfAny(argMultimap, editPersonDescriptor);
 
-        if (argMultimap.getValue(PREFIX_LEVEL_OF_EDUCATION).isPresent()) {
-            editPersonDescriptor.setLevelOfEducation(
-                    ParserUtil.parseLevelOfEducation(argMultimap.getValue(PREFIX_LEVEL_OF_EDUCATION).get()));
-        }
+        parseEmploymentTypeIfAny(argMultimap, editPersonDescriptor);
 
-        if (argMultimap.getValue(PREFIX_EXPERIENCE).isPresent()) {
-            editPersonDescriptor.setExperience(
-                    ParserUtil.parseExperience(argMultimap.getValue(PREFIX_EXPERIENCE).get()));
-        }
+        parseExpectedSalaryIfAny(argMultimap, editPersonDescriptor);
+
+        parseLevelOfEducationIfAny(argMultimap, editPersonDescriptor);
+
+        parseExperienceIfAny(argMultimap, editPersonDescriptor);
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
-        if (argMultimap.getValue(PREFIX_INTERVIEW).isPresent()) {
-            editPersonDescriptor.setInterview(
-                    ParserUtil.parseInterview(argMultimap.getValue(PREFIX_INTERVIEW).orElse("")));
-        }
+        parseInterviewIfAny(argMultimap, editPersonDescriptor);
 
-        if (argMultimap.getValue(PREFIX_NOTES).isPresent()) {
-            editPersonDescriptor.setNotes(
-                    ParserUtil.parseNotes(argMultimap.getValue(PREFIX_NOTES).orElse("")));
-        }
+        parseNotesIfAny(argMultimap, editPersonDescriptor);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
         return new EditCommand(index, editPersonDescriptor);
+    }
+
+    private void parseNotesIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_NOTES).isPresent()) {
+            editPersonDescriptor.setNotes(
+                    ParserUtil.parseNotes(argMultimap.getValue(PREFIX_NOTES).orElse("")));
+        }
+    }
+
+    private void parseInterviewIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_INTERVIEW).isPresent()) {
+            editPersonDescriptor.setInterview(
+                    ParserUtil.parseInterview(argMultimap.getValue(PREFIX_INTERVIEW).orElse("")));
+        }
+    }
+
+    private void parseExperienceIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_EXPERIENCE).isPresent()) {
+            editPersonDescriptor.setExperience(
+                    ParserUtil.parseExperience(argMultimap.getValue(PREFIX_EXPERIENCE).get()));
+        }
+    }
+
+    private void parseLevelOfEducationIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_LEVEL_OF_EDUCATION).isPresent()) {
+            editPersonDescriptor.setLevelOfEducation(
+                    ParserUtil.parseLevelOfEducation(argMultimap.getValue(PREFIX_LEVEL_OF_EDUCATION).get()));
+        }
+    }
+
+    private void parseExpectedSalaryIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_EXPECTED_SALARY).isPresent()) {
+            editPersonDescriptor.setExpectedSalary(ParserUtil.parseExpectedSalary(argMultimap
+                    .getValue(PREFIX_EXPECTED_SALARY).get()));
+        }
+    }
+
+    private void parseEmploymentTypeIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).isPresent()) {
+            editPersonDescriptor.setEmploymentType(
+                    ParserUtil.parseEmploymentType(argMultimap.getValue(PREFIX_EMPLOYMENT_TYPE).get()));
+        }
+    }
+
+    private void parseRoleIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_ROLE).isPresent()) {
+            editPersonDescriptor.setRole(ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get()));
+        }
+    }
+
+    private void parseEmailIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+    }
+
+    private void parsePhoneIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+    }
+
+    private void parseNameIfAny(ArgumentMultimap argMultimap, EditPersonDescriptor editPersonDescriptor)
+            throws ParseException {
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
     }
 
     /**


### PR DESCRIPTION
Addresses #382 
- Long methods extracted into shorter private methods in `EditCommandParser`
- `checkDisallowedDuplicates` method created to remove deep nesting in `EditCommand`